### PR TITLE
[hugo-updater] Update Hugo to version 0.91.0

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -2,7 +2,7 @@
   command = "hugo --gc --minify -b $URL"
 
 [build.environment]
-  HUGO_VERSION = "0.90.1"
+  HUGO_VERSION = "0.91.0"
   HUGO_ENABLEGITINFO = "true"
 
 [context.production.environment]


### PR DESCRIPTION
[hugo-updater] Update Hugo to version 0.91.0
More details in https://github.com/gohugoio/hugo/releases/tag/v0.91.0

Hugo `0.91.0` is mostly on the boring and technical side. See the list of changes below, but especially note the fix that allows passing _falsy_ arguments to partials with the `return` keyword (5758c370 #7528), thanks to [@ptgott](https://github.com/ptgott).

### Notes

This release contains some changes that may break your build:

### Use resources.GetRemote to fetch remote resources

In Hugo 0.90 we added remote support to `resources.Get`. In hindsight it was not a great idea use the same method for both, as a poll from many Hugo users showed. See Issue #9285 for more details. This release introduces `resources.GetRemote` which you need to use for remote resources. The example we showed in the release notes for `0.90.0` will now look like:

```htmlbars
{{ $font := resources.GetRemote "https://github.com/google/fonts/raw/main/apache/roboto/static/Roboto-Black.ttf" }}
{{ $img := resources.GetRemote "https://gohugo.io/images/gohugoio-card-1.png" }}
{{ $img = $img | images.Filter (images.Text 
                        "Rocks!!!" 
                        (dict 
                            "color" "#E6B405" 
                            "size" 100
                            "lineSpacing" 8 
                            "x" 400 "y" 320
                            "font" $font))
                     
}}
```

If you want to fetch any resource not having to consider where it lives, you can use a construct similar to the below:

 ```htmlbars
{{ resource := "" }}
{{ if (urls.Parse $url).IsAbs }}
  {{ $resource = resources.GetRemote $url }}
{{ else }}
  {{ $resource = resources.Get $url }}
{{ end }}
```

### New Security Configuration

This release also adds some new security hardening measures for the Hugo build runtime in the form of a new `security` configuration. There are some rarely used features in Hugo that would be good to have disabled by default. One example would be the "external helpers".

For `asciidoctor` and some others we use Go's `os/exec` package to start a new process. These are a predefined set of binary names, all loaded from `PATH` and with a predefined set of arguments. Still, if you don't use `asciidoctor` in your project, you might as well have it turned off.

You can configure this in the new `security` configuration section. The defaults are configured to create a minimal amount of site breakage, but if that do happen, you will get clear instructions in the console about what to do.

The default configuration is listed below. Note that almost all of these options are regular expression _whitelists_ (a string or a slice); the value `none` will block all.

```toml
[security]
  enableInlineShortcodes = false
  [security.exec]
    allow = ['^dart-sass-embedded$', '^go$', '^npx$', '^postcss$']
    osEnv = ['(?i)^(PATH|PATHEXT|APPDATA|TMP|TEMP|TERM)$']

  [security.funcs]
    getenv = ['^HUGO_']

  [security.http]
    methods = ['(?i)GET|POST']
    urls = ['.*']
```

You can read more about it in [Hugo's Security Model](https://gohugo.io/about/security-model/)

## Numbers

This release represents **23 contributions by 5 contributors** to the main Hugo code base.[@bep](https://github.com/bep) leads the Hugo development with a significant amount of contributions, but also a big shoutout to [@jmooring](https://github.com/jmooring), [@ptgott](https://github.com/ptgott), and [@jansorg](https://github.com/jansorg) for their ongoing contributions.
And thanks to [@digitalcraftsman](https://github.com/digitalcraftsman) for his ongoing work on keeping the themes site in pristine condition.

Many have also been busy writing and fixing the documentation in [hugoDocs](https://github.com/gohugoio/hugoDocs),
which has received **18 contributions by 2 contributors**.

Hugo now has:

* 55860+ [stars](https://github.com/gohugoio/hugo/stargazers)
* 430+ [contributors](https://github.com/gohugoio/hugo/graphs/contributors)
* 415+ [themes](http://themes.gohugo.io/)

## Changes

* docs: Regen docs helper 6df2f080 [@bep](https://github.com/bep) 
* tpl/resources: Add empty method mapping for GetRemote b84745d4 [@bep](https://github.com/bep) 
* Always use content to resolve content type in resources.GetRemote 44954497 [@bep](https://github.com/bep) #9302 #9301 
* Add resources.GetRemote 22ef5da2 [@bep](https://github.com/bep) #9285 #9296 
* Allow for return partials with falsy arguments (#9298) 5758c370 [@ptgott](https://github.com/ptgott) #7528 
* deps: Upgrade github.com/evanw/esbuild v0.14.2 => v0.14.5 8ee6de6d [@bep](https://github.com/bep) 
* don't use path.Join, because it cleans the final path a4b9f1a9 [@jansorg](https://github.com/jansorg) 
* Add some basic security policies with sensible defaults f4389e48 [@bep](https://github.com/bep) 
* Simplify Babel test assertions 803f572e [@bep](https://github.com/bep) 
* Improve handling of remote image/jpeg resources (#9278) a037be77 [@jmooring](https://github.com/jmooring) #9275 
* Fix Dockerfile 8a005538 [@hitzhangjie](https://github.com/hitzhangjie) #9261 
* Remove debug statement 657d0272 [@jmooring](https://github.com/jmooring) 
* Fix deprecation notice 159120cd [@bep](https://github.com/bep) 
* releaser: Prepare repository for 0.91.0-DEV 3f0d49e5 [@bep](https://github.com/bep) 
* releaser: Bump versions for release of 0.90.1 48907889 [@bep](https://github.com/bep) 
* releaser: Add release notes for 0.90.1 [ci skip] 3075eaa3 [@bep](https://github.com/bep) 
* Remove the retries on error in remote resources.Get 3bc68304 [@bep](https://github.com/bep) #9271 
* Allow user to handle/ignore errors in resources.Get e4d6ec94 [@bep](https://github.com/bep) #9529 
* Make resource.Get return nil on 404 not found 6260455b [@bep](https://github.com/bep) #9267 
* Update to Go 1.17.5 c397975a [@bep](https://github.com/bep) #9269 
* Update to Go 1.17.4 and remove timeout in resources.Get 965a6cbf [@bep](https://github.com/bep) #9265 






