### PR TITLE
[hugo-updater] Update Hugo to version 0.91.2

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -2,7 +2,7 @@
   command = "hugo --gc --minify -b $URL"
 
 [build.environment]
-  HUGO_VERSION = "0.91.0"
+  HUGO_VERSION = "0.91.2"
   HUGO_ENABLEGITINFO = "true"
 
 [context.production.environment]


### PR DESCRIPTION
[hugo-updater] Update Hugo to version 0.91.2
More details in https://github.com/gohugoio/hugo/releases/tag/v0.91.2



This is a bug-fix release with a couple of important fixes.

* Revert "config/security: Add HOME to default exec env var whitelist" 623dda71 [@bep](https://github.com/bep) 
* Make sure we always create the /public folder aee9e11a [@bep](https://github.com/bep) #8166 
* Fix "stuck on build" in error situations in content processing bd63c1aa [@bep](https://github.com/bep) #8166 
* deps: Run "go mod tidy" 9eb05807 [@bep](https://github.com/bep) 
* deps: Upgrade github.com/evanw/esbuild v0.14.7 => v0.14.8 654f513a [@bep](https://github.com/bep) 




