### PR TITLE
[hugo-updater] Update Hugo to version 0.93.2

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -2,7 +2,7 @@
   command = "hugo --gc --minify -b $URL"
 
 [build.environment]
-  HUGO_VERSION = "0.93.0"
+  HUGO_VERSION = "0.93.2"
   HUGO_ENABLEGITINFO = "true"
 
 [context.production.environment]


### PR DESCRIPTION
[hugo-updater] Update Hugo to version 0.93.2
More details in https://github.com/gohugoio/hugo/releases/tag/v0.93.2



This is a bug-fix release with a couple of important fixes.

* tpl/os: Revert readDir in theme behaviour 673cde1e @bep #9599 
* markup/goldmark: Escape image alt attribute e46e9ceb @jmooring #9594 




