### PR TITLE
[hugo-updater] Update Hugo to version 0.95.0

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -2,7 +2,7 @@
   command = "hugo --gc --minify -b $URL"
 
 [build.environment]
-  HUGO_VERSION = "0.94.2"
+  HUGO_VERSION = "0.95.0"
   HUGO_ENABLEGITINFO = "true"
 
 [context.production.environment]


### PR DESCRIPTION
[hugo-updater] Update Hugo to version 0.95.0
More details in https://github.com/gohugoio/hugo/releases/tag/v0.95.0

**Even faster, continue and break support, short-circuit of the built-in and/or-operators.** This release upgrades to Go 1.18 which was released yesterday. This has made Hugo even faster. How much faster will depend on your site etc., but we have [benchmarks](https://github.com/gohugoio/hugo/commit/9d6495d774233941b6e895e52870092fb1ca0134) that show significant improvements. But the main reason we're exited about this is the improvements in Go templates:

There are two new keywords, [`break` and `continue`](https://github.com/golang/go/issues/20531). These behaves like you would expect coming from other programming languages:

```htmlbars
{{ range $i, $p := site.RegularPages }}
  {{ if gt $i 2 }}
    {{/* Break out of range, we only want to print the first 3 pages. */}}
    {{ break }}
  {{ end }}
  {{ $p.Title }}
{{ end }}
```

```htmlbars
{{ range $i, $p := site.RegularPages }}
  {{ if eq $i 2 }}
    {{/* Skip the 3rd page. */}}
    {{ continue }}
  {{ end }}
  {{ $p.Title }}
{{ end }}
```

Also, the two built-in operators/function `and` and `or` now [short-circuits](https://github.com/golang/go/issues/31103), also in line with how `&&` and `||` behave in other programming languages. This is useful in situations where the right side may have side effects (may be `nil`, is slow to execute etc.):

```htmlbars
{{ if and .File (eq .File.Extension "html") }}
{{ end }}
```

Hugo now has:

* 57648+ [stars](https://github.com/gohugoio/hugo/stargazers)
* 429+ [contributors](https://github.com/gohugoio/hugo/graphs/contributors)
* 397+ [themes](http://themes.gohugo.io/)

## Notes

* Hugo now only builds with Go versions >= 1.18. Note that you do not need Go installed to run Hugo, and for Hugo Modules, any recent Go version can be used.

## Changes

* readme: Add note about Go 1.18 5930173c @bep 
* tpl: Pull in Go 1.18 patch that fixes the "no space in {{ continue }} and {{ break }}" bug 3476b533 @bep 
* readme: Add a contribution note e792d270 @bep 
* github: Make it build with Go 1.18 9d6495d7 @bep 
* tpl: Adjustments and an integration test for Go 1.18 42cc5f88 @bep #9677 
* Remove Go 1.17 support a6488e7b @bep #9677 
* tpl: Sync go_templates for Go 1.18 65a78cae @bep #9677 
* build: Bump to Go 1.18 4d6d1d08 @bep #9677 
* dartsass: Improve error message when no read access b60e1bbd @bep #9662 
* Fix and refactor typos 61cf3c9f @CathrinePaulsen 
* Improve server startup/shutdown 31fbc081 @bep #9671 
* commands: Improve server tests cebd886a @bep #9647 







