### PR TITLE
[hugo-updater] Update Hugo to version 0.97.2

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -2,7 +2,7 @@
   command = "hugo --gc --minify -b $URL"
 
 [build.environment]
-  HUGO_VERSION = "0.96.0"
+  HUGO_VERSION = "0.97.2"
   HUGO_ENABLEGITINFO = "true"
 
 [context.production.environment]


### PR DESCRIPTION
[hugo-updater] Update Hugo to version 0.97.2
More details in https://github.com/gohugoio/hugo/releases/tag/v0.97.2

**NOTE:** We seem to have introduced an issue with /static synching of files in this release, so we recommend wait for the`v0.97.3` and roll back to the `v0.97.0` or earlier for now.

This release reverts one of the fixes from yesterday, which broke more than it fixed:

* Revert "Fix PostProcess regression for hugo server" 6c35a1a9 @bep 




