### PR TITLE
[hugo-updater] Update Hugo to version 0.97.3

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -2,7 +2,7 @@
   command = "hugo --gc --minify -b $URL"
 
 [build.environment]
-  HUGO_VERSION = "0.96.0"
+  HUGO_VERSION = "0.97.3"
   HUGO_ENABLEGITINFO = "true"
 
 [context.production.environment]


### PR DESCRIPTION
[hugo-updater] Update Hugo to version 0.97.3
More details in https://github.com/gohugoio/hugo/releases/tag/v0.97.3

The `v0.97.x` release has been an Easter riddle. The new `--renderStaticToDisk` flag required a consolidation of the file systems in Hugo, which introduced a bug. The fix for that bug introduced a new bug, and reverting the obvious pick of the two candidate commits ... did not resolve the issue.

OK, all good things are three, and now with proper tests to avoid this particular issue happening again.

* Fix syncing of /static regression 9b352f04 @bep #9794 #9788 
* Revert "Revert "Fix PostProcess regression for hugo server"" e66e2e9c @bep #9794 




