### PR TITLE
[hugo-updater] Update Hugo to version 0.99.0

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -2,7 +2,7 @@
   command = "hugo --gc --minify -b $URL"
 
 [build.environment]
-  HUGO_VERSION = "0.98.0"
+  HUGO_VERSION = "0.99.0"
   HUGO_ENABLEGITINFO = "true"
 
 [context.production.environment]


### PR DESCRIPTION
[hugo-updater] Update Hugo to version 0.99.0
More details in https://github.com/gohugoio/hugo/releases/tag/v0.99.0

The theme of this release is **error handling** – a topic grievously underrated in most development tools. You are often expected to Google this mysterious error and end up in some Stackoverflow thread telling you to use a specific Node version. Hugo has done an OK job in this department, but when I, @bep, recently got stuck with a minify error I had no clue how to debug, I knew we had to take another look at this. There is a list of "error improvements below",  but here is one visual example:

![image](https://user-images.githubusercontent.com/394382/168581005-e22b20b6-d480-42f7-92ff-c07f034232cc.png)

The two screenshots above is from the same template error in Hugo `v0.98.0` (left) and the new `v0.99.0` (right). This is a _type error_ (method not found) in a partial included in a shortcode template. We did a decent job in `v0.98.0`, too, pointing at correct line in the partial. But the right version has the full stack, with absolute filename, line and column and some file context (highlighted lines) for all of the files involved in the error (Markdown file, shortcode and partial). Having these source file references to click on in the VS Code terminal is a real time saver, especially in Hugo projects with mulitiple file roots (themes, theme components).

A list of the most important "error improvements":

* A new server error template (can be overridden in `layouts/_server/error.html`), always add the content file context if relevant, improve JS errors, Add file context (with position) to codeblock render blocks, add file context to errors in the publishing step (e.g. minify), and more.  #9892 #9891 #9893
*  Fix SIGINT handling (allowing to kill the server) after loading bad configuration #9664
* Improve SASS/SCSS errors (both Dart SASS and Libsass) #9897
* Fix line numbers in errors from PostCSS, add missing file context to "import not found" #9895

Also worth mentioning is the new `clock` cli flag (#8787 ) which allows you to "set the clock" and see how your site looks like ... in the future.

This release represents **24 contributions by 4 contributors** to the main Hugo code base.[@bep](https://github.com/bep) leads the Hugo development with a significant amount of contributions, but also a big shoutout to [@dependabot[bot]](https://github.com/apps/dependabot), [@satotake](https://github.com/satotake), and [@nathannaveen](https://github.com/nathannaveen) for their ongoing contributions.

Many have also been busy writing and fixing the documentation in [hugoDocs](https://github.com/gohugoio/hugoDocs),
which has received **3 contributions by 2 contributors**.

Hugo now has:

* 58934+ [stars](https://github.com/gohugoio/hugo/stargazers)
* 428+ [contributors](https://github.com/gohugoio/hugo/graphs/contributors)
* 399+ [themes](http://themes.gohugo.io/)

## Notes

* Hugo will now by default fail the build if an inline import cannot be resolved with `inlineImports=true` enabled for `resources.PostCSS`. See https://gohugo.io/hugo-pipes/postcss/#options


## Changes

* server: Refresh the error template 657d1a2d @bep 
* server: Fix SIGINT handling after loading bad configuration 87a22eb6 @bep #9664 
* Improve SASS errors fc9f315d @bep #9897 
* postcss: Fix import error handling 4b189d8f @bep #9895 
* build(deps): bump github.com/fsnotify/fsnotify from 1.5.3 to 1.5.4 c2fa0a33 @dependabot[bot] 
* common/herrors: Remove unused struct 48ea24f8 @bep 
* build(deps): bump github.com/evanw/esbuild from 0.14.38 to 0.14.39 9f563856 @dependabot[bot] 
* errors: Misc improvements 5c96bda7 @bep #9892 #9891 #9893 
* server: Always rebuild the files involved in an error 4a96df96 @bep #9884 
* postcss: Fix line numbers in error messages e8537e6d @bep #9880 
* Update CONTRIBUTING.md 2fbdee72 @bep 
* js: Bump test dependency 91fe1b6c @bep 
* deps: Update github.com/spf13/cast v1.4.1 => v1.5.0 7de62912 @bep 
* hugolib: Check for nil in shouldRender 9d7f1662 @bep 
* Revise the use of htime.Since/htime.Now 51f08b0b @bep #9868 
* tpl/collections: Make sort stable 860c51c3 @bep #9865 
* docs: Regen CLI docs 855e5869 @bep 
* Use configured timeZone for the clock 35c88a7f @bep #8787 
* Add `clock` cli flag e77ca3c1 @satotake #8787 
* Improve error messages, esp. when the server is running f2946da9 @bep #9852 #9857 #9863 
* tpl: Improve godoc 6eea32bd @bep 
* github: Add permissions to test action a6d54585 @nathannaveen 
* tpl/crypto: Add example for FNV32a e5f21731 @bep 
* releaser: Prepare repository for 0.99.0-DEV 89c1655e @bep 






