### PR TITLE
[hugo-updater] Update Hugo to version 0.103.1

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -2,7 +2,7 @@
   command = "hugo --gc --minify -b $URL"
 
 [build.environment]
-  HUGO_VERSION = "0.102.3"
+  HUGO_VERSION = "0.103.1"
   HUGO_ENABLEGITINFO = "true"
 
 [context.production.environment]


### PR DESCRIPTION
[hugo-updater] Update Hugo to version 0.103.1
More details in https://github.com/gohugoio/hugo/releases/tag/v0.103.1

## What's Changed

* server: Fix redirects when file path contains bytes > 0x80 6be6752c @bep #10287 



