### PR TITLE
[hugo-updater] Update Hugo to version 0.104.0

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -2,7 +2,7 @@
   command = "hugo --gc --minify -b $URL"
 
 [build.environment]
-  HUGO_VERSION = "0.102.3"
+  HUGO_VERSION = "0.104.0"
   HUGO_ENABLEGITINFO = "true"
 
 [context.production.environment]


### PR DESCRIPTION
[hugo-updater] Update Hugo to version 0.104.0
More details in https://github.com/gohugoio/hugo/releases/tag/v0.104.0

Some bug fixes, dependency upgrades and a new `$image.Colors` [method](https://gohugo.io/content-management/image-processing/#colors). This method returns a slice of the most dominant colors in an image. The library we use is implemented by @marekm4 and is both fast and accurate. One use case for this may be to use as a placeholder before the image is loaded, as seen on this [Hugo gallery](https://staticbattery.com/) [[theme source]](https://github.com/bep/gallerydeluxe). You need a _slow enough_ internet connection to notice this effect so you may want to try this with Chrome's dev console open and throttle the network to _slow 3G_, which would make it look something like this:

https://user-images.githubusercontent.com/394382/191991430-93a73cf9-bd0b-4a12-801d-617cf3773369.mp4

## Bug fixes

* hugofs: Fix glob case-sensitivity bug 281554ee @satotake 
* server: Fix 404 redirects on Windows f3560aa0 @bep #10314 

## Improvements

* Consolidate the glob case logic 5c416533 @bep 
* Run go mod tidy 0171fb20 @bep 
* resources/images: Add $image.Colors a4028112 @bep #10307 
* commands: Skip flaky test on CI 08f0984f @bep 
* config/security: Allow proxy variables in subcommands 86653fa3 @sathieu 

## Dependency Updates

* build(deps): bump github.com/evanw/esbuild from 0.15.8 to 0.15.9 edf9038a @dependabot[bot] 
* build(deps): bump github.com/yuin/goldmark from 1.4.14 to 1.4.15 78f49b4c @dependabot[bot] 
* build(deps): bump github.com/getkin/kin-openapi from 0.100.0 to 0.103.0 fa4b77e7 @dependabot[bot] 
* build(deps): bump github.com/alecthomas/chroma/v2 from 2.2.0 to 2.3.0 4d909d47 @dependabot[bot] 
* build(deps): bump github.com/evanw/esbuild from 0.15.7 to 0.15.8 4eb6d974 @dependabot[bot] 

## Documentation

* docs: Regen docs helper 8377c3ce @bep 
* docs: Regenerate CLI docs 4f9cb4f3 @bep 


