### PR TITLE
[hugo-updater] Update Hugo to version 0.104.2

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -2,7 +2,7 @@
   command = "hugo --gc --minify -b $URL"
 
 [build.environment]
-  HUGO_VERSION = "0.104.1"
+  HUGO_VERSION = "0.104.2"
   HUGO_ENABLEGITINFO = "true"
 
 [context.production.environment]


### PR DESCRIPTION
[hugo-updater] Update Hugo to version 0.104.2
More details in https://github.com/gohugoio/hugo/releases/tag/v0.104.2

Fix htimes /: operation not permitted error on config changes when running the server. This regression was introduced in Hugo `v0.104.1`  4611b692 @bep 


