### PR TITLE
[hugo-updater] Update Hugo to version 0.111.3

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -2,7 +2,7 @@
   command = "hugo --gc --minify -b $URL"
 
 [build.environment]
-  HUGO_VERSION = "0.111.2"
+  HUGO_VERSION = "0.111.3"
   HUGO_ENABLEGITINFO = "true"
 
 [context.production.environment]


### PR DESCRIPTION
[hugo-updater] Update Hugo to version 0.111.3
More details in https://github.com/gohugoio/hugo/releases/tag/v0.111.3

## Bug fixes

* Fix "unknown shortcode token" when calling shortcode within fenced code block e7148f33 @bep #10819 
* Don't fail when calling Paginate with an empty pages.PagesGroup 34a86e13 @bep #10802 
* Improve error message for unclosed shortcode with inner content 9818724b @deining 

## Improvements

* tpl: Add hasSuffix alias d171d154 @jfish2 
* Run gofmt -s on source files d55af2ab @deining 
* tpl/math: Allow multi numbers in add, sub, mul, div, min and max 84201e8d @septs 
* server: Replace golang.org/x/net/context with context 0f01bd46 @alexandear 
* watcher: use time.NewTicker to prevent leaks 02ab77da @alexandear 
* ensure we default to 10 correctly 873be9f9 @davidejones 
* switch transfers to workers bebb2b8d @davidejones 
* customize parallel transfer count e6f029bd @davidejones 
* metadecoders: Add support for native org dates in frontmatter PR #7433 added support for Org timestamps for the DATE header. This PR widens the support with additional front matter headers LASTMOD, PUBLISHDATE and EXPIRYDATE. bdbfacb8 @johannesengl #8536 

## Dependency Updates

* deps: Update go-org to v1.6.6 1c841ec9 @niklasfasching 

## Documentation

* docs: Improve examples of variadic math functions b6f44aaf @jmooring 
* readme: Update dependency list 04b98116 @deining 


