### PR TITLE
[hugo-updater] Update Hugo to version 0.112.7

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -2,7 +2,7 @@
   command = "hugo --gc --minify -b $URL"
 
 [build.environment]
-  HUGO_VERSION = "0.112.5"
+  HUGO_VERSION = "0.112.7"
   HUGO_ENABLEGITINFO = "true"
 
 [context.production.environment]


### PR DESCRIPTION
[hugo-updater] Update Hugo to version 0.112.7
More details in https://github.com/gohugoio/hugo/releases/tag/v0.112.7

## What's Changed

* Fix menuItem.URL when pageRef is not set 5e5ce00d @bep #11062 
* Don't inject livereload script on hugo -w a191b38a @bep #11061 
* markup: Fix typo in function and struct names 382c726e @alexandear 
* all: Replace deprecated ioutil with io and os 4c46f940 @alexandear 


