### PR TITLE
[hugo-updater] Update Hugo to version 0.113.0

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -2,7 +2,7 @@
   command = "hugo --gc --minify -b $URL"
 
 [build.environment]
-  HUGO_VERSION = "0.112.7"
+  HUGO_VERSION = "0.113.0"
   HUGO_ENABLEGITINFO = "true"
 
 [context.production.environment]


### PR DESCRIPTION
[hugo-updater] Update Hugo to version 0.113.0
More details in https://github.com/gohugoio/hugo/releases/tag/v0.113.0

This release adds TLS/HTTPS support to `hugo server` (see cf38c73f and #11064  for details) entirely backed by [mkcert](https://github.com/FiloSottile/mkcert). We still default to `http` which is recommended and good enough for 99% of the Hugo use, but there are [some situations](https://web.dev/when-to-use-local-https/) where you really need it.

We have added a new sub command and some new flags to `hugo server` to enable this:

```
# Installs a local CA in the system root store. You only need to do this once.
hugo server trust

#  Generates locally-trusted certificates (if not already created) and starts the server with TLS/HTTPS enabled.
hugo server --tlsAuto
```

Note that we just delegate to [mkcert](https://github.com/FiloSottile/mkcert) using its default settings, so all of their documentation is relevant. 

Also note that this is currently only supported for Linux, MacOS and Windows. And if you install on Linux using Snap, you will currently get an access denied error when running `hugo server trust`. A workaround for that, or if you need to use some of mkcert's advanced options, is to use mkcert directly to install the local CA:

```
go install filippo.io/mkcert@latest
mkcert -install
```

You can then start the server with `hugo server --tlsAuto`.

If you have obtained the TLS certificate and key file by other means, you can use the `--tlsCertFile` and `--tlsKeyFile` flags. When `--tlsAuto` or `--tlsCertFile` and `--tlsKeyFile` is set and no `--baseURL` is provided as a flag, the server is started with TLS and `https` as the protocol.




