### PR TITLE
[hugo-updater] Update Hugo to version 0.115.2

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -2,7 +2,7 @@
   command = "hugo --gc --minify -b $URL"
 
 [build.environment]
-  HUGO_VERSION = "0.115.0"
+  HUGO_VERSION = "0.115.2"
   HUGO_ENABLEGITINFO = "true"
 
 [context.production.environment]


### PR DESCRIPTION
[hugo-updater] Update Hugo to version 0.115.2
More details in https://github.com/gohugoio/hugo/releases/tag/v0.115.2

## Bug fixes

* Fix hugo mod vendor for modules with hugo.toml 0f921ace @bep #11221 
* Fix static content files multilingual root regression 60199537 @bep #11223 
* Fix defaultContentLanguageInSubdir with only 1 language 92e86702 @bep #10064 
* Make imageConfig work with modules a78b17d7 @bep #11205 
* Restore language.disabled config a4819425 @bep #11219 

## Improvements

* config: Expand default security.exec.osEnv policy 6c9ea022 @dvdksn #9333 
* Add titleCaseStyle none and firstupper 12d3469d @bep #11204 
* Bump github.com/bep/clock v0.3.0 to renamed github.com/bep/clocks v0.5.0 bf7ee8a9 @anthonyfok 

## Build Setup

* snap: Allow access to AWS, Azure, and GCS config/credentials 72510969 @jmooring #11122 
* snap: Update metadata and security.exec.osEnv 70c5e485 @jmooring #11217 


