### PR TITLE
[hugo-updater] Update Hugo to version 0.120.3

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -2,7 +2,7 @@
   command = "hugo --gc --minify -b $URL"
 
 [build.environment]
-  HUGO_VERSION = "0.119.0"
+  HUGO_VERSION = "0.120.3"
   HUGO_ENABLEGITINFO = "true"
 
 [context.production.environment]


### PR DESCRIPTION
[hugo-updater] Update Hugo to version 0.120.3
More details in https://github.com/gohugoio/hugo/releases/tag/v0.120.3

## What's Changed

* tpl/tplimpl: Fix deprecation logic in embedded templates cb98e9061 @jmooring #11658 
* Remove some old and unused deprecation code 5fa97ee96 @bep 
* Add a field prefix to the deprecated log statements 4d38f4725 @bep 
* Avoid double printing INFO deprecation messages 80f793c38 @bep #11645 
* build(deps): bump github.com/tdewolff/parse/v2 from 2.7.1 to 2.7.3 a9079d7a6 @dependabot[bot] 
* build(deps): bump github.com/tdewolff/minify/v2 from 2.20.1 to 2.20.5 4914b7f18 @dependabot[bot] 


