### PR TITLE
[hugo-updater] Update Hugo to version 0.121.1

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -2,7 +2,7 @@
   command = "hugo --gc --minify -b $URL"
 
 [build.environment]
-  HUGO_VERSION = "0.120.4"
+  HUGO_VERSION = "0.121.1"
   HUGO_ENABLEGITINFO = "true"
 
 [context.production.environment]


### PR DESCRIPTION
[hugo-updater] Update Hugo to version 0.121.1
More details in https://github.com/gohugoio/hugo/releases/tag/v0.121.1

The only change in this release is that the release binaries are compiled with [Go 1.21.5](https://github.com/golang/go/issues?q=milestone%3AGo1.21.5+label%3ACherryPickApproved) which contains some [security fixes](https://groups.google.com/g/golang-announce/c/iLGK3x6yuNo) that are relevant for Hugo.

* Upgrade to Go 1.21.5 eb9f1eb65 @bep #11786 


