### PR TITLE
[hugo-updater] Update Hugo to version 0.123.3

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -2,7 +2,7 @@
   command = "hugo --gc --minify -b $URL"
 
 [build.environment]
-  HUGO_VERSION = "0.122.0"
+  HUGO_VERSION = "0.123.3"
   HUGO_ENABLEGITINFO = "true"
 
 [context.production.environment]


### PR DESCRIPTION
[hugo-updater] Update Hugo to version 0.123.3
More details in https://github.com/gohugoio/hugo/releases/tag/v0.123.3

## Bug fixes

* hugolib: Fix a .Page.GetPage from bundle case f521336c8 @bep #12120 
* cache/dynacache: Reset ticker in case one cache eviction takes some time 03b88c6dd @bep #12129 
* Speed up GetPage bf14d0cb2 @bep 
* resources: Skip the image golden tests when running locally c4fe45ff4 @bep #12119 
* js: Support JSX and JSXImportSourceOptions 554aa58db @baltpeter #12118 
* hugolib: Add capitalizeListTitles config option 36bf3cb98 @jmooring #9793 #12115 


