### PR TITLE
[hugo-updater] Update Hugo to version 0.123.8

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -2,7 +2,7 @@
   command = "hugo --gc --minify -b $URL"
 
 [build.environment]
-  HUGO_VERSION = "0.122.0"
+  HUGO_VERSION = "0.123.8"
   HUGO_ENABLEGITINFO = "true"
 
 [context.production.environment]


### PR DESCRIPTION
[hugo-updater] Update Hugo to version 0.123.8
More details in https://github.com/gohugoio/hugo/releases/tag/v0.123.8


* docs: Fix hyphens and grammar in synopsis of command 'hugo server' ada3fceea @deining 
* Fix resource name in resources.ByType a4b17470a @bep #12190 
* Fix global resource isn't published when using an uncommon code construct 4d5e173cf @bep #12190 
* Fix section page resource not published if resource filename partially matches content file name 4271b6be0 @bep #12198 
* Fix taxonomy kind template lookup issue 0567a3e6f @bep #12193 
* markup/goldmark: TOC: render strikethrough, emojis 134e7d1d3 @lyind #7169 #11783 #12022 
* Add hugo.IsMultiHost 1f48b717c @razonyang 
* resources/images: Retain newlines with text overlays 05e23bd55 @jmooring #12206 
* Don't auto-create empty sections for nested taxonomies 7afac3f1a @bep #12188 
* tpl/tplimpl: Honor markdown attributes in embedded image render hook 632ad74fc @jmooring #12203 


