### PR TITLE
[hugo-updater] Update Hugo to version 0.124.0

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -2,7 +2,7 @@
   command = "hugo --gc --minify -b $URL"
 
 [build.environment]
-  HUGO_VERSION = "0.122.0"
+  HUGO_VERSION = "0.124.0"
   HUGO_ENABLEGITINFO = "true"
 
 [context.production.environment]


### PR DESCRIPTION
[hugo-updater] Update Hugo to version 0.124.0
More details in https://github.com/gohugoio/hugo/releases/tag/v0.124.0

The new feature in this release is a new [segments](https://gohugo.io/getting-started/configuration/#configure-segments) configuration section and a new `--renderSegments` flag/config key. This release also updates to Go 1.22.1 that fixes a security issue in the template package that Hugo uses (CVE-2023-45289, see https://github.com/golang/go/issues/65697). We don't see how this could be exploited in Hugo, but we appreciate that Hugo users want to have a clean security report.

## Bug fixes

* Fix .Parent when there are overlapping regular pages inbetween f1d755965 @bep #12263 
* hugolib: Fix sitemap index with monolingual site 3935faa41 @jmooring #12266 
* all: Typo fixes 78178d0c2 @coliff 
* Fix translationKey handling for term pages 68d92ef9d @bep #12261 
* Fix intersect and similar for term entry page collections b40f3c7df @bep #12254 
* Fix server rebuilds when adding sub sections especially on Windows 07b2e535b @bep #12230 
* Fix panic when changing archetype files when servere is running 9ca1de09d @bep #12195 
* Fix front matter date location when value gets inherited from other dates 9668759ad @bep #12236 
* Fix Name for nested resourced fetched in resources.ByName and similar 9e9b1f110 @bep #12214 

## Improvements

* Add segments config + --renderSegments flag 1f1c62e6c @bep #10106 
* hugolib: Remove Site.HomeAbsURL 558f74f00 @bep 
* hugolib: Deprecate site methods Author, Authors, and Social d4d49e0f0 @jmooring #12228 
* Upgrade to Go 1.22.1 57206e727 @bep #12250 
* tpl/tplimpl: Modify figure shortcode to look for page resource 48a0fea87 @jmooring #12244 #12245 
* common/hugo: Rename IsMultiHost and IsMultiLingual dc6a29213 @jmooring #12232 
* hugolib: Deprecate .Site.MultiLingual in favor of hugo.IsMultiLingual 4f92f949e @jmooring #12224 
* tpl/tplimpl: Remove deprecated method from sitemapindex.xml f038a51b3 @jmooring 


## Dependency Updates

* deps: Upgrade github.com/gohugoio/hugo-goldmark-extensions/passthrough v0.1.0 => v0.2.0 ba03114aa @bep 
* build(deps): bump github.com/evanw/esbuild from 0.20.1 to 0.20.2 b1f867634 @dependabot[bot] 
* build(deps): bump golang.org/x/tools from 0.18.0 to 0.19.0 b4bff6190 @dependabot[bot] 
* build(deps): bump github.com/tdewolff/minify/v2 from 2.20.17 to 2.20.19 d2cebee27 @dependabot[bot] 
* deps: Upgrade github.com/alecthomas/chroma/v2 to v2.13.0 be914ff34 @myitcv #11862 
* build(deps): bump golang.org/x/mod from 0.15.0 to 0.16.0 e62675002 @dependabot[bot] 

## Documentation

* docs: Regen CLI docs 76ef3f42f @bep 
* docs: Regen docshelper 0ccb6cdc0 @bep 

## Build Setup

* snap: Transition to from core20 to core22 d24ffdde5 @jmooring #12219 


