### PR TITLE
[hugo-updater] Update Hugo to version 0.124.1

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -2,7 +2,7 @@
   command = "hugo --gc --minify -b $URL"
 
 [build.environment]
-  HUGO_VERSION = "0.122.0"
+  HUGO_VERSION = "0.124.1"
   HUGO_ENABLEGITINFO = "true"
 
 [context.production.environment]


### PR DESCRIPTION
[hugo-updater] Update Hugo to version 0.124.1
More details in https://github.com/gohugoio/hugo/releases/tag/v0.124.1

## What's Changed

* Fix potential deadlock in Translations 758a876f9 @bep #12129 
* Fix rebuild when changing mixed case named templates 19937a20a @bep #12165 
* testing: Set usesFMA as true for riscv64 too c1ea22a23 @anthonyfok 
* Fix regression for outputs defined in front matter for term pages 0750a9ec9 @bep #12275 


