### PR TITLE
[hugo-updater] Update Hugo to version 0.126.1

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -2,7 +2,7 @@
   command = "hugo --gc --minify -b $URL"
 
 [build.environment]
-  HUGO_VERSION = "0.122.0"
+  HUGO_VERSION = "0.126.1"
   HUGO_ENABLEGITINFO = "true"
 
 [context.production.environment]


### PR DESCRIPTION
[hugo-updater] Update Hugo to version 0.126.1
More details in https://github.com/gohugoio/hugo/releases/tag/v0.126.1

## What's Changed

* Fix mixed case Page params handling in content adapters 39cf906bc @bep #12497 
* Fix paths with dots issue with content adapters 1aacfced3 @bep #12493 




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated build environment to use Hugo version 0.126.1 for improved performance and new features.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->