### PR TITLE
[hugo-updater] Update Hugo to version 0.128.0

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -2,7 +2,7 @@
   command = "hugo --gc --minify -b $URL"
 
 [build.environment]
-  HUGO_VERSION = "0.122.0"
+  HUGO_VERSION = "0.128.0"
   HUGO_ENABLEGITINFO = "true"
 
 [context.production.environment]


### PR DESCRIPTION
[hugo-updater] Update Hugo to version 0.128.0
More details in https://github.com/gohugoio/hugo/releases/tag/v0.128.0



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated Hugo version from 0.122.0 to 0.128.0 for improved build performance and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->