### PR TITLE
[hugo-updater] Update Hugo to version 0.131.0

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -2,7 +2,7 @@
   command = "hugo --gc --minify -b $URL"
 
 [build.environment]
-  HUGO_VERSION = "0.128.2"
+  HUGO_VERSION = "0.131.0"
   HUGO_ENABLEGITINFO = "true"
 
 [context.production.environment]


### PR DESCRIPTION
[hugo-updater] Update Hugo to version 0.131.0
More details in https://github.com/gohugoio/hugo/releases/tag/v0.131.0



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the Hugo version to 0.131.0, enhancing potential performance, security, and new features of the site.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->