### PR TITLE
[hugo-updater] Update Hugo to version 0.136.5

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -2,7 +2,7 @@
   command = "hugo --gc --minify -b $URL"
 
 [build.environment]
-  HUGO_VERSION = "0.128.2"
+  HUGO_VERSION = "0.136.5"
   HUGO_ENABLEGITINFO = "true"
 
 [context.production.environment]


### PR DESCRIPTION
[hugo-updater] Update Hugo to version 0.136.5
More details in https://github.com/gohugoio/hugo/releases/tag/v0.136.5



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the Hugo version in the build environment to enhance site generation capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->