### PR TITLE
[hugo-updater] Update Hugo to version 0.149.0

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -2,7 +2,7 @@
   command = "hugo --gc --minify -b $URL"
 
 [build.environment]
-  HUGO_VERSION = "0.146.4"
+  HUGO_VERSION = "0.149.0"
   HUGO_ENABLEGITINFO = "true"
 
 [context.production.environment]


### PR DESCRIPTION
[hugo-updater] Update Hugo to version 0.149.0
More details in https://github.com/gohugoio/hugo/releases/tag/v0.149.0

