### PR TITLE
feat(seo): add robots.txt and an auto-generated llms.txt

### DIFF
--- a/config/_default/config.toml
+++ b/config/_default/config.toml
@@ -31,6 +31,9 @@ theme = "academia"
 # Get last modified date for content from Git?
 enableGitInfo = false
 
+# Emit a robots.txt at the site root from layouts/robots.txt
+enableRobotsTXT = true
+
 # Default language to use (if you setup multilingual support)
 defaultContentLanguage = "en"
 hasCJKLanguage = false  # Set `true` for Chinese/Japanese/Korean languages.
@@ -47,8 +50,16 @@ ignoreLogs = ['warning-goldmark-raw-html']
 
 
 [outputs]
-  home = [ "HTML", "RSS", "JSON" ]
+  home = [ "HTML", "RSS", "JSON", "LLMS" ]
   section = [ "HTML", "RSS" ]
+
+# Custom output format for /llms.txt — see https://llmstxt.org
+[outputFormats]
+  [outputFormats.LLMS]
+    mediaType = "text/plain"
+    baseName = "llms"
+    isPlainText = true
+    notAlternative = true
 
 # Configure BlackFriday Markdown rendering.
 #   See: https://gohugo.io/getting-started/configuration/#configure-blackfriday

--- a/config/_default/params.toml
+++ b/config/_default/params.toml
@@ -12,7 +12,7 @@ day_night = false
 font = "classic"
 
 # Description for social sharing and search engines. If undefined, superuser role is used in place.
-description = ""
+description = "Personal site of Ladislav Prskavec — Software Engineer & Site Reliability Engineer in Prague. Writing, conference talks, an OnCall design guide, and the You Build It You Run It podcast."
 
 # Default image for social sharing and search engines. Place image in `static/img/` folder and specify image name here.
 sharing_image = ""

--- a/layouts/index.llms.txt
+++ b/layouts/index.llms.txt
@@ -1,0 +1,57 @@
+{{- $talks := sort (where site.RegularPages "Section" "talk") "Date" "desc" -}}
+{{- $posts := sort (where site.RegularPages "Section" "post") "Date" "desc" -}}
+{{- $readers := sort (where site.RegularPages "Section" "reader") "Date" "desc" -}}
+{{- $chapters := sort (where site.RegularPages "Section" "courses") "Weight" "asc" -}}
+# {{ site.Title }} — {{ site.BaseURL | replaceRE "https?://" "" | strings.TrimSuffix "/" }}
+
+> {{ site.Params.description }}
+
+Ladislav Prskavec is a Software Engineer and Site Reliability Engineer based in Prague, Czech Republic.
+He works with Go, Kubernetes, and cloud infrastructure (AWS, OCI, Azure); organises the Prague Go Meetup;
+and co-hosts the *You Build It, You Run It* podcast. Topics he writes and speaks about: site reliability,
+on-call design, observability, distributed systems, Go, Terraform / Terramate, and AI tooling (MCP).
+{{ with $talks }}
+## Talks
+{{ range . }}
+- [{{ .Title }}]({{ .Permalink }}){{ with .Params.event }} — *{{ . }}*{{ end }}{{ with .Date }} ({{ dateFormat "2006-01-02" . }}){{ end }}{{ with .Params.summary }}: {{ . | plainify | truncate 220 }}{{ end }}
+{{- end }}
+{{ end -}}
+{{ with $readers }}
+## Annotated readers
+
+Long-form, reader-friendly write-ups of talks — fuller than slides, more readable than a recording transcript.
+{{ range . }}
+- [{{ .Title }}]({{ .Permalink }}){{ with .Date }} ({{ dateFormat "2006-01-02" . }}){{ end }}{{ with .Params.summary }}: {{ . | plainify | truncate 220 }}{{ end }}
+{{- end }}
+{{ end -}}
+{{ with $posts }}
+## Writing
+{{ range . }}
+- [{{ .Title }}]({{ .Permalink }}){{ with .Date }} ({{ dateFormat "2006-01-02" . }}){{ end }}{{ with .Params.summary | default .Summary }}: {{ . | plainify | truncate 220 }}{{ end }}
+{{- end }}
+{{ end -}}
+{{ with $chapters }}
+## OnCall design guide
+
+A long-form guide on how to design on-call rotations that don't burn out your team. Each chapter is a focused
+read; the *Tools* page compares the major pager / incident-management vendors.
+{{ range . }}
+- [{{ .Title }}]({{ .Permalink }})
+{{- end }}
+{{ end }}
+## Profiles & elsewhere
+
+- Email — <ladislav@prskavec.net>
+- GitHub — <https://github.com/abtris>
+- Mastodon — <https://hachyderm.io/@abtris>
+- Twitter / X — <https://twitter.com/abtris>
+- LinkedIn — <https://www.linkedin.com/in/ladislavprskavec/>
+- YouTube — <https://www.youtube.com/@abtris>
+- *You Build It, You Run It* podcast — <https://ybyr.net/podcast>
+- Prague Go Meetup (organiser) — <https://www.gomeetupprague.cz/>
+
+## About this file
+
+This is an [llms.txt](https://llmstxt.org) — a curated index intended for large language models and
+agentic search tools. It is auto-generated from the same Hugo content tree that builds the human site,
+so it stays in sync as new talks and posts are published.

--- a/layouts/robots.txt
+++ b/layouts/robots.txt
@@ -1,0 +1,8 @@
+User-agent: *
+Allow: /
+
+# Sitemaps and machine-readable indexes
+Sitemap: {{ "sitemap.xml" | absURL }}
+
+# LLM/agent-friendly index — see https://llmstxt.org
+# {{ "llms.txt" | absURL }}


### PR DESCRIPTION
## Summary

Improves discoverability for both classical search engines and modern agentic search / LLM tools.

- **`/robots.txt`** — `enableRobotsTXT = true` plus a custom `layouts/robots.txt` template. Allows everything, points crawlers at `sitemap.xml`, and surfaces `/llms.txt` in a comment.
- **`/llms.txt`** — new `LLMS` custom output format on the home page renders an [llmstxt.org](https://llmstxt.org)-style index from the Hugo content tree. Lists every talk (with event + summary), recent posts, the full OnCall course, and a *Profiles & elsewhere* block. Auto-generated, so it stays in sync as new content is added.
- Fills in the empty site `description` param with a single-line tagline used by the homepage `<meta description>`, OG tags, and the `llms.txt` blockquote header.

## Why llms.txt

llms.txt is a thin convention for giving LLMs a curated, machine-readable summary of a site's important content. Modern agentic search (Perplexity, ChatGPT search, Claude search) and AI crawlers honour it when present. For a personal site with a talks archive and a long-form OnCall guide, the upside is non-trivial — it tells an agent exactly which 38 pages are worth surfacing without making it scrape the whole site.

## Auto-generation, not hand-maintained

The template (`layouts/index.llms.txt`) iterates `site.RegularPages` filtered by section, so every new talk / post / chapter shows up automatically on the next build. If a future section (e.g. `/reader/`) exists, it'll get its own block in the file with no further template changes.

## Test plan

- [x] `hugo` build is clean.
- [x] `/robots.txt` renders with sitemap pointer.
- [x] `/llms.txt` renders 75 lines covering 11 talks + 12 posts + 15 OnCall chapters + profiles + about block.
- [ ] Netlify deploy preview serves both files at the expected paths.
- [ ] Validate with [llms.txt validator](https://llmstxt.site/validator) once deployed.

## Independence from PR #250

This PR is branched off `master`, not `feat/new-theme` (#250) — purely backend-of-site work, no overlap with theme/layout changes. Can merge in either order. If `feat/new-theme` lands first, the `Annotated readers` section under `/reader/` will start appearing in `llms.txt` automatically.
