### PR TITLE
feat(search): add Algolia-backed command-palette search overlay

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,11 @@
+{
+  "esversion": 11,
+  "browser": true,
+  "undef": true,
+  "unused": false,
+  "globals": {
+    "console": true,
+    "AbortController": true,
+    "fetch": true
+  }
+}

--- a/assets/css/input.css
+++ b/assets/css/input.css
@@ -813,6 +813,284 @@
   border: 0;
 }
 
+/* ── Search overlay (command-palette style) ─────────────────────── */
+.nav-search {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.3rem 0.5rem 0.3rem 0.55rem;
+  font-family: var(--font-mono);
+  font-size: 1rem;
+  color: var(--color-paper-dim);
+  background: transparent;
+  border: 1px solid var(--color-rule);
+  border-radius: 3px;
+  cursor: pointer;
+  transition: color 0.15s ease, border-color 0.15s ease;
+}
+
+.nav-search:hover,
+.nav-search:focus-visible {
+  color: var(--color-paper);
+  border-color: var(--color-rule-bright);
+}
+
+.nav-search-kbd {
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  letter-spacing: 0.04em;
+  color: var(--color-paper-faint);
+  padding: 0.1rem 0.35rem;
+  border: 1px solid var(--color-rule-bright);
+  border-radius: 2px;
+  background: var(--color-ink-deep);
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+/* Overlay */
+.search-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 100;
+  display: none;
+  align-items: flex-start;
+  justify-content: center;
+  padding: 6vh 1rem 1rem;
+}
+
+.search-overlay[data-open="true"] {
+  display: flex;
+}
+
+.search-backdrop {
+  position: absolute;
+  inset: 0;
+  background:
+    radial-gradient(1200px circle at 50% 0%, rgba(255, 92, 46, 0.06), transparent 60%),
+    rgba(5, 5, 4, 0.85);
+  backdrop-filter: blur(6px);
+  -webkit-backdrop-filter: blur(6px);
+}
+
+.search-panel {
+  position: relative;
+  width: 100%;
+  max-width: 640px;
+  background: var(--color-ink);
+  border: 1px solid var(--color-rule-bright);
+  border-left: 2px solid var(--color-signal);
+  border-radius: 6px;
+  box-shadow: 0 30px 80px -20px rgba(0, 0, 0, 0.7);
+  max-height: 80vh;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  animation: search-rise 0.18s cubic-bezier(0.2, 0.7, 0.2, 1) both;
+}
+
+@keyframes search-rise {
+  from { opacity: 0; transform: translateY(-8px) scale(0.99); }
+  to   { opacity: 1; transform: translateY(0) scale(1); }
+}
+
+.search-panel-header {
+  display: flex;
+  align-items: center;
+  gap: 0.85rem;
+  padding: 1rem 1.1rem;
+  border-bottom: 1px solid var(--color-rule);
+}
+
+.search-icon {
+  font-family: var(--font-mono);
+  font-size: 1.4rem;
+  color: var(--color-signal);
+  line-height: 1;
+}
+
+#search-input {
+  flex: 1;
+  background: transparent;
+  border: 0;
+  outline: 0;
+  color: var(--color-paper);
+  font-family: var(--font-display);
+  font-size: 1.55rem;
+  font-style: italic;
+  caret-color: var(--color-signal);
+  padding: 0.1rem 0;
+}
+
+#search-input::placeholder {
+  color: var(--color-paper-faint);
+  font-style: italic;
+}
+
+.search-close {
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  letter-spacing: 0.06em;
+  padding: 0.2rem 0.45rem;
+  border: 1px solid var(--color-rule-bright);
+  border-radius: 2px;
+  background: transparent;
+  color: var(--color-paper-dim);
+  cursor: pointer;
+  transition: color 0.15s ease, border-color 0.15s ease;
+}
+
+.search-close:hover {
+  color: var(--color-signal);
+  border-color: var(--color-signal);
+}
+
+.search-results {
+  list-style: none;
+  padding: 0.25rem 0;
+  margin: 0;
+  overflow-y: auto;
+  scrollbar-color: var(--color-rule-bright) transparent;
+}
+
+.search-hit {
+  display: grid;
+  grid-template-columns: 5rem 1fr auto;
+  gap: 0.85rem;
+  align-items: baseline;
+  padding: 0.85rem 1.1rem;
+  border-bottom: 1px dashed var(--color-rule);
+  text-decoration: none;
+  color: inherit;
+  transition: background 0.12s ease;
+}
+
+.search-results li:last-child .search-hit { border-bottom: 0; }
+
+.search-hit[aria-selected="true"] {
+  background: rgba(255, 92, 46, 0.07);
+}
+
+.search-hit[aria-selected="true"] .search-hit-title {
+  color: var(--color-signal);
+}
+
+.search-hit-section {
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  letter-spacing: var(--tracking-label);
+  text-transform: uppercase;
+  color: var(--color-paper-dim);
+  padding-top: 0.15rem;
+}
+
+.search-hit-body {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  min-width: 0;
+}
+
+.search-hit-title {
+  font-family: var(--font-display);
+  font-size: 1.25rem;
+  line-height: 1.15;
+  color: var(--color-paper);
+  text-wrap: balance;
+}
+
+.search-hit-summary {
+  font-family: var(--font-body);
+  font-size: 0.95rem;
+  line-height: 1.45;
+  color: var(--color-paper-dim);
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.search-hit-arrow {
+  font-family: var(--font-mono);
+  font-size: 1rem;
+  color: var(--color-paper-faint);
+  align-self: center;
+}
+
+.search-hit[aria-selected="true"] .search-hit-arrow {
+  color: var(--color-signal);
+}
+
+.search-hit mark {
+  background: rgba(255, 92, 46, 0.22);
+  color: var(--color-signal-warm);
+  padding: 0 0.05em;
+  border-radius: 1px;
+}
+
+.search-empty {
+  padding: 2rem 1.25rem;
+  font-family: var(--font-body);
+  font-style: italic;
+  color: var(--color-paper-dim);
+  text-align: center;
+}
+
+.search-empty[data-visible="false"] {
+  display: none;
+}
+
+.search-footer {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  padding: 0.7rem 1.1rem;
+  border-top: 1px solid var(--color-rule);
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  color: var(--color-paper-faint);
+  letter-spacing: 0.02em;
+  flex-wrap: wrap;
+}
+
+.search-footer kbd {
+  display: inline-block;
+  font-family: var(--font-mono);
+  font-size: 0.68rem;
+  padding: 0.05rem 0.35rem;
+  margin-right: 0.25rem;
+  border: 1px solid var(--color-rule-bright);
+  border-radius: 2px;
+  background: var(--color-ink-deep);
+  color: var(--color-paper-dim);
+}
+
+.search-attribution {
+  margin-left: auto;
+}
+
+@media (max-width: 640px) {
+  .nav-search-kbd { display: none; }
+  .search-overlay { padding: 3vh 0.5rem 0.5rem; }
+  #search-input { font-size: 1.25rem; }
+  .search-hit { grid-template-columns: 1fr auto; gap: 0.5rem; }
+  .search-hit-section {
+    grid-column: 1 / -1;
+    padding: 0;
+  }
+}
+
 /* Hide focus ring on mouse, keep on keyboard */
 :focus-visible {
   outline: 2px solid var(--color-signal);

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -10,5 +10,7 @@
       {{ block "main" . }}{{ end }}
     </main>
     {{ partial "footer.html" . }}
+    {{ partial "search-overlay.html" . }}
+    <script src="{{ "/js/search.js" | relURL }}" defer></script>
   </body>
 </html>

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -14,6 +14,11 @@
       <a class="nav-link" data-active="{{ hasPrefix $cur "/post" }}" href="{{ "/post/" | relURL }}">Writing</a>
       <a class="nav-link" data-active="{{ hasPrefix $cur "/courses" }}" href="{{ "/courses/how-to-make-oncall/" | relURL }}">Oncall</a>
       <a class="nav-link" href="https://ybyr.net/podcast" target="_blank" rel="noopener">Podcast ↗</a>
+      <button type="button" class="nav-search" data-search-trigger aria-label="Open search (press /)">
+        <span aria-hidden="true">⌕</span>
+        <span class="sr-only">Search</span>
+        <kbd class="nav-search-kbd" aria-hidden="true">/</kbd>
+      </button>
     </nav>
   </div>
 </header>

--- a/layouts/partials/search-overlay.html
+++ b/layouts/partials/search-overlay.html
@@ -1,0 +1,27 @@
+<div id="search-overlay" class="search-overlay" data-open="false" role="dialog" aria-modal="true" aria-label="Search the site">
+  <div class="search-backdrop" data-search-close></div>
+  <div class="search-panel" role="document">
+    <div class="search-panel-header">
+      <span class="search-icon" aria-hidden="true">⌕</span>
+      <input
+        id="search-input"
+        type="search"
+        autocomplete="off"
+        autocapitalize="off"
+        autocorrect="off"
+        spellcheck="false"
+        placeholder="Search talks, posts, chapters…"
+        aria-label="Search">
+
+      <button type="button" class="search-close" data-search-close aria-label="Close search">ESC</button>
+    </div>
+    <ul id="search-results" class="search-results" role="listbox" aria-label="Search results"></ul>
+    <div id="search-empty" class="search-empty" data-visible="true">Try a search above.</div>
+    <div class="search-footer">
+      <span><kbd>↑</kbd><kbd>↓</kbd> navigate</span>
+      <span><kbd>↵</kbd> open</span>
+      <span><kbd>esc</kbd> close</span>
+      <span class="search-attribution">Powered by Algolia</span>
+    </div>
+  </div>
+</div>

--- a/static/js/search.js
+++ b/static/js/search.js
@@ -1,0 +1,226 @@
+/* jshint esversion: 11, browser: true */
+// Search overlay for prskavec.net — queries the Algolia blog_hugo index
+// directly via REST (the key below is a search-only key, safe to expose).
+//
+// UI: command-palette modal opened via the header button or the "/" key.
+// Keyboard: ↑↓ to move, Enter to open, Esc to close.
+
+(function () {
+  'use strict';
+
+  const APP_ID = 'MVMZX0V323';
+  const SEARCH_KEY = 'fb75ba39d4a2a4dbd39e69a66cff0777';
+  const INDEX = 'blog_hugo';
+  const ENDPOINT = `https://${APP_ID}-dsn.algolia.net/1/indexes/${INDEX}/query`;
+  const HITS_PER_PAGE = 8;
+  const DEBOUNCE_MS = 180;
+
+  // Friendly section labels for the result chips.
+  const SECTION_LABELS = {
+    talk: 'Talk',
+    post: 'Writing',
+    reader: 'Reader',
+    courses: 'Course',
+    authors: 'About',
+  };
+
+  const overlay = document.getElementById('search-overlay');
+  const input = document.getElementById('search-input');
+  const results = document.getElementById('search-results');
+  const empty = document.getElementById('search-empty');
+  const triggers = document.querySelectorAll('[data-search-trigger]');
+
+  if (!overlay || !input || !results) return;
+
+  let selectedIndex = 0;
+  let currentHits = [];
+  let debounceTimer = null;
+  let abortController = null;
+
+  function open() {
+    overlay.dataset.open = 'true';
+    document.body.style.overflow = 'hidden';
+    setTimeout(() => input.focus(), 30);
+  }
+
+  function close() {
+    overlay.dataset.open = 'false';
+    document.body.style.overflow = '';
+    input.value = '';
+    currentHits = [];
+    selectedIndex = 0;
+    results.innerHTML = '';
+    if (empty) empty.dataset.visible = 'true';
+  }
+
+  function escapeHTML(s) {
+    return String(s).replace(/[&<>"']/g, (c) => ({
+      '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;',
+    })[c]);
+  }
+
+  function highlight(html) {
+    // Algolia returns _highlightResult fragments with <em>...</em> wrappers
+    // marking matched terms — keep those, but escape everything else.
+    if (!html) return '';
+    // Split on <em>...</em>, escape outside, leave inside (but escape its
+    // content too — Algolia values shouldn't contain raw HTML, but be safe).
+    return html.replace(/<em>([\s\S]*?)<\/em>/g, (_, inner) =>
+      `<mark>${escapeHTML(inner)}</mark>`
+    ).replace(/<(?!\/?mark>)/g, '&lt;');
+  }
+
+  function renderHits(hits) {
+    currentHits = hits || [];
+    selectedIndex = 0;
+    if (!currentHits.length) {
+      results.innerHTML = '';
+      if (empty) {
+        empty.dataset.visible = 'true';
+        empty.textContent = input.value.trim() ?
+          `No results for “${input.value.trim()}”.` :
+          'Try a search above.';
+      }
+      return;
+    }
+    if (empty) empty.dataset.visible = 'false';
+
+    results.innerHTML = currentHits.map((hit, i) => {
+      const sectionLabel = SECTION_LABELS[hit.section] || hit.section || 'Page';
+      const titleH = (hit._highlightResult && hit._highlightResult.title && hit._highlightResult.title.value) || escapeHTML(hit.title || '');
+      const summary =
+        (hit._highlightResult && hit._highlightResult.summary && hit._highlightResult.summary.value) ||
+        (hit._snippetResult && hit._snippetResult.content && hit._snippetResult.content.value) ||
+        escapeHTML((hit.summary || '').slice(0, 180));
+      return `
+        <li>
+          <a href="${escapeHTML(hit.relpermalink || hit.permalink || '#')}"
+             class="search-hit"
+             data-i="${i}"
+             aria-selected="${i === selectedIndex}">
+            <span class="search-hit-section">${escapeHTML(sectionLabel)}</span>
+            <span class="search-hit-body">
+              <span class="search-hit-title">${highlight(titleH)}</span>
+              ${summary ? `<span class="search-hit-summary">${highlight(summary)}</span>` : ''}
+            </span>
+            <span class="search-hit-arrow" aria-hidden="true">↗</span>
+          </a>
+        </li>
+      `;
+    }).join('');
+
+    bindHitMouseHandlers();
+  }
+
+  function bindHitMouseHandlers() {
+    results.querySelectorAll('.search-hit').forEach((el) => {
+      el.addEventListener('mouseenter', () => {
+        selectedIndex = Number(el.dataset.i);
+        updateSelection();
+      });
+    });
+  }
+
+  function updateSelection() {
+    const hits = results.querySelectorAll('.search-hit');
+    hits.forEach((el, i) => {
+      el.setAttribute('aria-selected', i === selectedIndex ? 'true' : 'false');
+      if (i === selectedIndex) el.scrollIntoView({ block: 'nearest' });
+    });
+  }
+
+  async function runSearch(query) {
+    if (abortController) abortController.abort();
+    abortController = new AbortController();
+
+    if (!query.trim()) {
+      renderHits([]);
+      return;
+    }
+    try {
+      const res = await fetch(ENDPOINT, {
+        method: 'POST',
+        headers: {
+          'X-Algolia-Application-Id': APP_ID,
+          'X-Algolia-API-Key': SEARCH_KEY,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          query: query,
+          hitsPerPage: HITS_PER_PAGE,
+          attributesToSnippet: ['content:24', 'summary:24'],
+          highlightPreTag: '<em>',
+          highlightPostTag: '</em>',
+        }),
+        signal: abortController.signal,
+      });
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const data = await res.json();
+      renderHits(data.hits || []);
+    } catch (err) {
+      if (err.name === 'AbortError') return;
+      if (empty) {
+        empty.dataset.visible = 'true';
+        empty.textContent = 'Search is temporarily unavailable.';
+      }
+      results.innerHTML = '';
+    }
+  }
+
+  input.addEventListener('input', () => {
+    clearTimeout(debounceTimer);
+    debounceTimer = setTimeout(() => runSearch(input.value), DEBOUNCE_MS);
+  });
+
+  input.addEventListener('keydown', (e) => {
+    if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      if (currentHits.length) {
+        selectedIndex = (selectedIndex + 1) % currentHits.length;
+        updateSelection();
+      }
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      if (currentHits.length) {
+        selectedIndex = (selectedIndex - 1 + currentHits.length) % currentHits.length;
+        updateSelection();
+      }
+    } else if (e.key === 'Enter') {
+      if (currentHits.length) {
+        e.preventDefault();
+        const hit = currentHits[selectedIndex];
+        if (hit) {
+          window.location.href = hit.relpermalink || hit.permalink;
+        }
+      }
+    } else if (e.key === 'Escape') {
+      e.preventDefault();
+      close();
+    }
+  });
+
+  overlay.addEventListener('click', (e) => {
+    // Click on the backdrop (not the inner panel) closes
+    if (e.target === overlay || e.target.dataset.searchClose) close();
+  });
+
+  document.addEventListener('keydown', (e) => {
+    // "/" opens the overlay (GitHub-style); skipped when the user is typing
+    // in any form field so they can still type a literal slash there.
+    if (e.key === '/' && overlay.dataset.open !== 'true') {
+      const tag = (e.target.tagName || '').toLowerCase();
+      const editable = e.target.isContentEditable || tag === 'input' || tag === 'textarea' || tag === 'select';
+      if (!editable) {
+        e.preventDefault();
+        open();
+      }
+    }
+  });
+
+  triggers.forEach((btn) => {
+    btn.addEventListener('click', (e) => {
+      e.preventDefault();
+      open();
+    });
+  });
+})();

--- a/tests/search.spec.ts
+++ b/tests/search.spec.ts
@@ -1,133 +1,116 @@
 import { test, expect } from '@playwright/test';
 
 /**
- * Algolia search tests.
+ * Search overlay tests.
  *
- * The site uses instantsearch.js with the Algolia backend.
- * DOM structure:
- *   nav#navbar-main a.nav-link.js-search  — navbar search icon (toggle)
- *   <aside id="search" class="search-results"> — overlay (visibility:hidden by default)
- *     Overlay becomes visible when <body> gets class "searching"
- *     <div id="search-box"> — instantsearch injects an <input class="ais-SearchBox-input"> here
- *     <div id="search-hits"> — results container
+ * The new theme ships a command-palette modal that queries the Algolia
+ * blog_hugo index directly via REST (search-only key). DOM shape:
  *
- * Note: there is a second a.js-search (the ✕ close button) INSIDE the overlay which
- * is hidden; always select the navbar icon via a.nav-link.js-search.
+ *   button[data-search-trigger]      — header trigger
+ *   #search-overlay                  — modal container, [data-open] toggled
+ *   #search-input                    — the search field
+ *   #search-results > li > a.search-hit  — each result row
+ *   #search-empty                    — empty / no-results state
  */
 
-// The Algolia search overlay was part of the Academia theme and has not yet
-// been re-implemented in the new theme. The Algolia index is still being
-// built (see algolia.go) so re-adding a search UI is a follow-up. Tests
-// disabled to keep CI green; re-enable once a search UI is wired up.
-test.describe.skip('Algolia search', () => {
-  test.beforeEach(async ({ page, isMobile }) => {
+test.describe('Search overlay', () => {
+  test.beforeEach(async ({ page }) => {
     await page.goto('/');
-    // Wait for the page JS (including instantsearch) to initialise
-    await page.waitForLoadState('networkidle');
-    // On mobile the navbar collapses; open the hamburger so the search icon is visible.
-    if (isMobile) {
-      await page.locator('button.navbar-toggler').click();
-      await expect(page.locator('#navbar')).toBeVisible();
-    }
+    // Defer-loaded script — make sure it's wired up before interacting.
+    await page.waitForFunction(() =>
+      document.querySelector('[data-search-trigger]') !== null
+    );
   });
 
-  test('search icon is present in navbar', async ({ page }) => {
-    // The navbar icon has both nav-link and js-search classes; the overlay close
-    // button has only js-search, so we must be specific to avoid picking the hidden one.
-    const searchIcon = page.locator('a.nav-link.js-search');
-    await expect(searchIcon).toBeVisible();
+  test('header shows a search trigger button', async ({ page }) => {
+    const trigger = page.locator('[data-search-trigger]');
+    await expect(trigger).toBeVisible();
   });
 
-  test('clicking search icon opens the search overlay', async ({ page }) => {
-    // Overlay uses visibility:hidden by default; body gains class "searching" on open.
-    const overlay = page.locator('aside#search');
-    await expect(overlay).toBeHidden();
+  test('clicking the trigger opens the overlay', async ({ page }) => {
+    const overlay = page.locator('#search-overlay');
+    await expect(overlay).toHaveAttribute('data-open', 'false');
 
-    await page.locator('a.nav-link.js-search').click();
+    await page.locator('[data-search-trigger]').click();
 
-    await expect(overlay).toBeVisible({ timeout: 5_000 });
+    await expect(overlay).toHaveAttribute('data-open', 'true');
+    await expect(page.locator('#search-input')).toBeFocused();
   });
 
-  test('instantsearch renders an input inside #search-box', async ({ page }) => {
-    await page.locator('a.nav-link.js-search').click();
-
-    // instantsearch.js injects <input class="ais-SearchBox-input"> (or similar)
-    const input = page.locator('#search-box input');
-    await expect(input).toBeVisible({ timeout: 5_000 });
+  test('pressing "/" opens the overlay from the page body', async ({ page }) => {
+    const overlay = page.locator('#search-overlay');
+    await page.locator('body').click();
+    await page.keyboard.press('/');
+    await expect(overlay).toHaveAttribute('data-open', 'true');
+    await expect(page.locator('#search-input')).toBeFocused();
   });
 
-  test('typing a query returns results from Algolia', async ({ page }) => {
-    await page.locator('a.nav-link.js-search').click();
+  test('typing a query returns hits from Algolia', async ({ page }) => {
+    await page.locator('[data-search-trigger]').click();
+    await page.locator('#search-input').fill('go');
 
-    const input = page.locator('#search-box input');
-    await expect(input).toBeVisible({ timeout: 5_000 });
-
-    await input.fill('go');
-
-    // #search-hits becomes visible and contains at least one hit
-    const hits = page.locator('#search-hits');
-    await expect(hits).toBeVisible({ timeout: 10_000 });
-
-    // Wait for at least one search-hit div from Algolia
-    const firstHit = hits.locator('.search-hit').first();
+    const firstHit = page.locator('#search-results .search-hit').first();
     await expect(firstHit).toBeVisible({ timeout: 10_000 });
 
-    // The hit should contain a link
-    await expect(firstHit.locator('a')).toBeVisible();
+    await expect(firstHit.locator('.search-hit-title')).toBeVisible();
+    await expect(firstHit.locator('.search-hit-section')).toBeVisible();
   });
 
-  test('search results contain a clickable link that navigates', async ({ page }) => {
-    await page.locator('a.nav-link.js-search').click();
+  test('hits are real links that navigate when clicked', async ({ page }) => {
+    await page.locator('[data-search-trigger]').click();
+    await page.locator('#search-input').fill('go');
 
-    const input = page.locator('#search-box input');
-    await expect(input).toBeVisible({ timeout: 5_000 });
-    await input.fill('go');
+    const firstHit = page.locator('#search-results .search-hit').first();
+    await expect(firstHit).toBeVisible({ timeout: 10_000 });
 
-    const firstHitLink = page.locator('#search-hits .search-hit a').first();
-    await expect(firstHitLink).toBeVisible({ timeout: 10_000 });
-
-    const href = await firstHitLink.getAttribute('href');
+    const href = await firstHit.getAttribute('href');
     expect(href).toBeTruthy();
-    expect(href).toMatch(/prskavec\.net|^\//);
+    expect(href).toMatch(/^\/|prskavec\.net/);
+
+    await firstHit.click();
+    await expect(page).not.toHaveURL(/\/$|^http:\/\/localhost:1313\/$/);
   });
 
-  test('empty query hides the results container', async ({ page }) => {
-    await page.locator('a.nav-link.js-search').click();
+  test('a query with no matches shows the empty state', async ({ page }) => {
+    await page.locator('[data-search-trigger]').click();
+    await page.locator('#search-input').fill('xyzzy1234noresults');
 
-    const input = page.locator('#search-box input');
-    await expect(input).toBeVisible({ timeout: 5_000 });
-
-    // Type something first so hits appear, then clear it
-    await input.fill('go');
-    await expect(page.locator('#search-hits')).toBeVisible({ timeout: 10_000 });
-
-    await input.fill('');
-    // The algolia-search.js sets display:none when query is empty
-    await expect(page.locator('#search-hits')).toHaveCSS('display', 'none', { timeout: 5_000 });
+    const empty = page.locator('#search-empty');
+    await expect(empty).toHaveAttribute('data-visible', 'true', { timeout: 10_000 });
+    await expect(empty).toContainText(/no results/i);
   });
 
-  test('no-match query shows "no results" message', async ({ page }) => {
-    await page.locator('a.nav-link.js-search').click();
+  test('Esc closes the overlay', async ({ page }) => {
+    await page.locator('[data-search-trigger]').click();
+    const overlay = page.locator('#search-overlay');
+    await expect(overlay).toHaveAttribute('data-open', 'true');
 
-    const input = page.locator('#search-box input');
-    await expect(input).toBeVisible({ timeout: 5_000 });
-
-    // A query unlikely to match anything in the index
-    await input.fill('xyzzy1234noresults');
-
-    const hits = page.locator('#search-hits');
-    await expect(hits).toBeVisible({ timeout: 10_000 });
-    await expect(hits.locator('.search-no-results')).toBeVisible({ timeout: 10_000 });
+    await page.keyboard.press('Escape');
+    await expect(overlay).toHaveAttribute('data-open', 'false');
   });
 
-  test('closing search overlay with × button hides it', async ({ page }) => {
-    await page.locator('a.nav-link.js-search').click();
-    const overlay = page.locator('aside#search');
-    await expect(overlay).toBeVisible({ timeout: 5_000 });
+  test('clicking the backdrop closes the overlay', async ({ page }) => {
+    await page.locator('[data-search-trigger]').click();
+    const overlay = page.locator('#search-overlay');
+    await expect(overlay).toHaveAttribute('data-open', 'true');
 
-    // The ✕ close button inside the overlay also has class js-search (but NOT nav-link)
-    await overlay.locator('a.js-search').click();
-    await expect(overlay).toBeHidden({ timeout: 5_000 });
+    await page.locator('.search-backdrop').click();
+    await expect(overlay).toHaveAttribute('data-open', 'false');
+  });
+
+  test('arrow keys move selection between hits', async ({ page }) => {
+    await page.locator('[data-search-trigger]').click();
+    await page.locator('#search-input').fill('go');
+
+    const hits = page.locator('#search-results .search-hit');
+    await expect(hits.first()).toBeVisible({ timeout: 10_000 });
+
+    await expect(hits.nth(0)).toHaveAttribute('aria-selected', 'true');
+
+    await page.keyboard.press('ArrowDown');
+    await expect(hits.nth(1)).toHaveAttribute('aria-selected', 'true');
+
+    await page.keyboard.press('ArrowUp');
+    await expect(hits.nth(0)).toHaveAttribute('aria-selected', 'true');
   });
 });
-


### PR DESCRIPTION
## Summary

Closes the last open item from #253 — **item 15, search UI**.

The Algolia `blog_hugo` index continues to be built and pushed independently by `algolia.go` in CI; this PR only adds the **consumer** — a command-palette-style search overlay in the new theme.

## What's in the box

- **`static/js/search.js`** (~7 KB, vanilla, no framework) — queries Algolia's REST endpoint directly with the **search-only API key** (read-only, safe to expose client-side). Debounced 180 ms. Highlights matched terms in titles and snippets using `<mark>` with a signal-orange wash.
- **`layouts/partials/search-overlay.html`** — command-palette modal: blurred dark backdrop, signal-orange left-stripe panel, italic display-serif search input with a signal-orange caret, results list with per-hit section chip (`TALK` / `WRITING` / `READER` / `COURSE` / `ABOUT`), footer with keyboard hints.
- **Search trigger** added to the header nav: a small `⌕  /` button so the keyboard shortcut is discoverable.
- **Loaded from `baseof.html`** with `defer` — zero blocking on the rest of the page.

## Keyboard

- **`/`** opens the overlay from anywhere (except when you're typing in a form field — the literal slash still works there).
- **`Esc`** closes.
- **`↑` / `↓`** navigate results.
- **`Enter`** opens the selected hit.
- Click the backdrop or the `ESC` chip to close.

The Cmd+P / Cmd+K shortcuts were dropped in favour of just `/` (per chat) — keeps native browser shortcuts intact.

## Responsive

- Under 640 px: the kbd hint in the header is hidden; the result-section chip wraps above the title; the modal occupies more of the viewport.

## Linting / pre-commit

The repo's existing pre-commit hook runs `jshint -` on staged JS via stdin. Two small additions to keep that green going forward:

- New `.jshintrc` at project root: `{ "esversion": 11, "browser": true, undef: true, … }`.
- Inline `/* jshint esversion: 11, browser: true */` directive at the top of `search.js` (stdin invocations don't pick up the rc file automatically, hence the belt-and-braces approach).

You may need `npm install -g jshint` locally once if it isn't already installed (the hook checks for it).

## Test plan

- [x] `make css && hugo` builds cleanly.
- [x] `/js/search.js` serves at 200 (7 KB).
- [x] Algolia REST endpoint returns hits — verified live: 24 hits for `go`.
- [x] Search button visible in the nav with the `/` kbd hint.
- [x] Overlay markup is in the DOM on every page (`baseof.html` includes the partial).
- [ ] Manual browser test: press `/`, type a query, navigate with `↑↓`, open a hit, close with `Esc`.
- [ ] Verify on Netlify deploy preview.

## Stacked on #257

Branched off `feat/dead-content-cleanup` (#257) so the diff stays minimal. Merge order: #256 → #257 → this. GitHub should auto-rebase once the upstream PRs land.

## Tracking issue

After this PR, **#253 is fully closed** — every punch-list item from the post-redesign walkthrough is shipped.