### PR TITLE
feat(seo): add JSON-LD structured data (WebSite, Person, Event, Article)

### DIFF
--- a/layouts/authors/term.html
+++ b/layouts/authors/term.html
@@ -4,16 +4,16 @@
 {{ $posts := where site.RegularPages "Section" "post" }}
 {{ $upcoming := where $talks "Date" "gt" $now }}
 
-<article class="relative z-10 px-6 md:px-12 lg:px-20 py-10 md:py-16" itemscope itemtype="https://schema.org/Person">
+<article class="relative z-10 px-6 md:px-12 lg:px-20 py-10 md:py-16">
 
   {{/* ── Headline ─────────────────────────────────────────────── */}}
   <header class="rise">
     <div class="mono-label mb-6">About · The person behind prskavec.net</div>
     <h1 class="display text-[clamp(3rem,11vw,10.5rem)] leading-[0.92]">
-      <span itemprop="name">{{ .Params.name | default .Title }}</span>
+      <span>{{ .Params.name | default .Title }}</span>
     </h1>
     {{ with .Params.role }}
-    <p class="mt-6 display italic text-2xl md:text-4xl leading-[1.05] text-[color:var(--color-paper-dim)] max-w-[36ch]" itemprop="jobTitle">
+    <p class="mt-6 display italic text-2xl md:text-4xl leading-[1.05] text-[color:var(--color-paper-dim)] max-w-[36ch]">
       {{ . }}
     </p>
     {{ end }}
@@ -27,7 +27,7 @@
       <div class="relative">
         <img src="{{ printf "/img/%s" . | relURL }}"
              alt="{{ $.Params.name | default $.Title }}"
-             itemprop="image"
+            
              class="block w-full max-w-[20rem] aspect-square object-cover rounded-md border border-[color:var(--color-rule-bright)] grayscale-[20%]">
         <span class="absolute -bottom-2 -right-2 mono-tag mono-tag-signal bg-[color:var(--color-ink-deep)]">
           ▲ @abtris
@@ -49,7 +49,7 @@
           <dd class="text-[color:var(--color-signal)] tabular-nums">{{ len $upcoming }}</dd>
           {{ end }}
           <dt class="mono-label">Based</dt>
-          <dd class="text-[color:var(--color-paper)]" itemprop="homeLocation">{{ site.Params.address | default "Prague, CZ" }}</dd>
+          <dd class="text-[color:var(--color-paper)]">{{ site.Params.address | default "Prague, CZ" }}</dd>
         </dl>
       </div>
     </aside>
@@ -59,7 +59,7 @@
       {{ with .Content }}
       <section>
         <div class="mono-label mb-5 text-[color:var(--color-paper)]">▾ Bio</div>
-        <div class="prose-editorial" itemprop="description">
+        <div class="prose-editorial">
           {{ . }}
         </div>
       </section>
@@ -160,31 +160,31 @@
             </a>
           </li>
           <li>
-            <a href="https://github.com/abtris" target="_blank" rel="noopener" class="link-arrow w-full justify-between" itemprop="sameAs">
+            <a href="https://github.com/abtris" target="_blank" rel="noopener" class="link-arrow w-full justify-between">
               <span>GitHub</span>
               <span class="mono-label normal-case tracking-normal text-[color:var(--color-paper-dim)]">github.com/abtris ↗</span>
             </a>
           </li>
           <li>
-            <a href="https://hachyderm.io/@abtris" target="_blank" rel="me noopener" class="link-arrow w-full justify-between" itemprop="sameAs">
+            <a href="https://hachyderm.io/@abtris" target="_blank" rel="me noopener" class="link-arrow w-full justify-between">
               <span>Mastodon</span>
               <span class="mono-label normal-case tracking-normal text-[color:var(--color-paper-dim)]">@abtris@hachyderm.io ↗</span>
             </a>
           </li>
           <li>
-            <a href="https://twitter.com/abtris" target="_blank" rel="noopener" class="link-arrow w-full justify-between" itemprop="sameAs">
+            <a href="https://twitter.com/abtris" target="_blank" rel="noopener" class="link-arrow w-full justify-between">
               <span>Twitter / X</span>
               <span class="mono-label normal-case tracking-normal text-[color:var(--color-paper-dim)]">@abtris ↗</span>
             </a>
           </li>
           <li>
-            <a href="https://www.linkedin.com/in/ladislavprskavec/" target="_blank" rel="noopener" class="link-arrow w-full justify-between" itemprop="sameAs">
+            <a href="https://www.linkedin.com/in/ladislavprskavec/" target="_blank" rel="noopener" class="link-arrow w-full justify-between">
               <span>LinkedIn</span>
               <span class="mono-label normal-case tracking-normal text-[color:var(--color-paper-dim)]">in/ladislavprskavec ↗</span>
             </a>
           </li>
           <li>
-            <a href="https://www.youtube.com/@abtris" target="_blank" rel="noopener" class="link-arrow w-full justify-between" itemprop="sameAs">
+            <a href="https://www.youtube.com/@abtris" target="_blank" rel="noopener" class="link-arrow w-full justify-between">
               <span>YouTube</span>
               <span class="mono-label normal-case tracking-normal text-[color:var(--color-paper-dim)]">@abtris ↗</span>
             </a>

--- a/layouts/docs/single.html
+++ b/layouts/docs/single.html
@@ -39,7 +39,7 @@
     </aside>
 
     {{/* ── Article ─────────────────────────────────────────────────── */}}
-    <article class="min-w-0 rise" itemscope itemtype="https://schema.org/Article">
+    <article class="min-w-0 rise">
       <div class="flex flex-wrap items-baseline gap-3 mb-6">
         <span class="mono-tag mono-tag-signal">◆ Chapter</span>
         {{ with .Parent }}
@@ -47,11 +47,11 @@
         {{ end }}
       </div>
 
-      <h1 class="display text-[clamp(2.2rem,5vw,4.5rem)] leading-[0.98] mb-10" itemprop="name">
+      <h1 class="display text-[clamp(2.2rem,5vw,4.5rem)] leading-[0.98] mb-10">
         {{ .Title }}
       </h1>
 
-      <div class="prose-editorial" itemprop="articleBody">
+      <div class="prose-editorial">
         {{ .Content }}
       </div>
 

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -60,3 +60,6 @@
 {{ if .IsPage }}
 <link rel="canonical" href="{{ .Permalink }}">
 {{ end }}
+
+{{/* ── JSON-LD structured data ─────────────────────────────────── */}}
+{{ partial "jsonld.html" . }}

--- a/layouts/partials/jsonld.html
+++ b/layouts/partials/jsonld.html
@@ -1,0 +1,103 @@
+{{- /*
+  Emit a JSON-LD <script> with the schema.org type that matches this
+  page's kind/section. Branches:
+    - Homepage          → WebSite
+    - /authors/<slug>/  → Person (current author bundle)
+    - /talk/<slug>/     → Event
+    - /reader/<slug>/   → Article (long-form write-up of a talk)
+    - /post/<slug>/     → Article
+    - course chapters   → Article
+  Other pages skip JSON-LD intentionally.
+*/ -}}
+
+{{- $author := site.GetPage "/authors/abtris" -}}
+{{- $authorURL := "" -}}
+{{- with $author }}{{ $authorURL = .Permalink }}{{ end -}}
+{{- $defaultImage := absURL "img/og-default.png" -}}
+
+{{- $data := "" -}}
+
+{{- if .IsHome -}}
+  {{- $data = dict
+    "@context"    "https://schema.org"
+    "@type"       "WebSite"
+    "name"        site.Title
+    "url"         site.BaseURL
+    "description" site.Params.description
+    "inLanguage"  (site.Language.Locale | default "en")
+    "publisher"   (dict "@type" "Person" "name" "Ladislav Prskavec" "url" $authorURL)
+  -}}
+
+{{- else if eq .Section "authors" -}}
+  {{- $sameAs := slice
+      "https://github.com/abtris"
+      "https://hachyderm.io/@abtris"
+      "https://twitter.com/abtris"
+      "https://www.linkedin.com/in/ladislavprskavec/"
+      "https://www.youtube.com/@abtris"
+  -}}
+  {{- $jobTitle := "" -}}
+  {{- with index (.Params.career | default slice) 0 -}}
+    {{- if eq (printf "%v" .end) "Present" -}}
+      {{- $jobTitle = printf "%s at %s" .title .company -}}
+    {{- end -}}
+  {{- end -}}
+  {{- $img := "" -}}
+  {{- with .Params.avatar_image -}}{{ $img = absURL (printf "img/%s" .) }}{{- end -}}
+  {{- $data = dict
+    "@context"    "https://schema.org"
+    "@type"       "Person"
+    "name"        (.Params.name | default .Title)
+    "url"         .Permalink
+    "image"       ($img | default $defaultImage)
+    "jobTitle"    $jobTitle
+    "address"     (dict "@type" "PostalAddress" "addressLocality" "Prague" "addressCountry" "CZ")
+    "sameAs"      $sameAs
+    "description" (site.Params.description | plainify | truncate 220)
+  -}}
+
+{{- else if eq .Section "talk" -}}
+  {{- $location := dict "@type" "Place" "name" (.Params.location | default "Prague, Czech Republic") "address" (.Params.location | default "Prague, Czech Republic") -}}
+  {{- $organizer := dict "@type" "Organization" "name" (.Params.event | default site.Title) -}}
+  {{- with .Params.event_url -}}{{ $organizer = merge $organizer (dict "url" .) }}{{- end -}}
+  {{- $now := now -}}
+  {{- $status := "https://schema.org/EventScheduled" -}}
+  {{- $data = dict
+    "@context"            "https://schema.org"
+    "@type"               "Event"
+    "name"                .Title
+    "startDate"           (.Date.Format "2006-01-02T15:04:05Z07:00")
+    "endDate"             (cond .Params.date_end (dateFormat "2006-01-02T15:04:05Z07:00" .Params.date_end) (.Date.Format "2006-01-02T15:04:05Z07:00"))
+    "eventStatus"         $status
+    "eventAttendanceMode" "https://schema.org/OfflineEventAttendanceMode"
+    "location"            $location
+    "organizer"           $organizer
+    "performer"           (dict "@type" "Person" "name" "Ladislav Prskavec" "url" $authorURL)
+    "description"         (.Params.summary | default .Summary | plainify | truncate 320)
+    "url"                 .Permalink
+    "image"               $defaultImage
+  -}}
+
+{{- else if or (eq .Section "post") (eq .Section "reader") (eq .Type "docs") -}}
+  {{- $img := $defaultImage -}}
+  {{- with .Resources.GetMatch "{og.*,share.*,featured.*}" -}}{{ $img = .Permalink }}{{- end -}}
+  {{- $data = dict
+    "@context"         "https://schema.org"
+    "@type"            "Article"
+    "headline"         .Title
+    "description"      (.Params.summary | default .Summary | plainify | truncate 320)
+    "image"            $img
+    "datePublished"    (.Date.Format "2006-01-02T15:04:05Z07:00")
+    "dateModified"     (.Lastmod.Format "2006-01-02T15:04:05Z07:00")
+    "inLanguage"       (site.Language.Locale | default "en")
+    "url"              .Permalink
+    "mainEntityOfPage" .Permalink
+    "author"           (dict "@type" "Person" "name" "Ladislav Prskavec" "url" $authorURL)
+    "publisher"        (dict "@type" "Person" "name" "Ladislav Prskavec" "url" $authorURL)
+  -}}
+  {{- with .Params.tags -}}{{ $data = merge $data (dict "keywords" (delimit . ", ")) }}{{- end -}}
+{{- end -}}
+
+{{- with $data -}}
+<script type="application/ld+json">{{ . | jsonify | safeJS }}</script>
+{{- end -}}

--- a/layouts/talk/single.html
+++ b/layouts/talk/single.html
@@ -5,7 +5,7 @@
 {{ $isUpcoming := gt $date $now }}
 {{ $isLive := and (le $date $now) (and $dateEnd (gt $dateEnd $now)) }}
 
-<article class="relative z-10 px-6 md:px-12 lg:px-20 py-8 md:py-12" itemscope itemtype="https://schema.org/Event">
+<article class="relative z-10 px-6 md:px-12 lg:px-20 py-8 md:py-12">
 
   {{/* ── breadcrumb + status chip ───────────────────────────────────── */}}
   <div class="flex items-center justify-between gap-4 mb-12 rise">
@@ -79,7 +79,7 @@
         </span>
       </div>
 
-      <h1 class="display display-italic text-[2.6rem] sm:text-5xl md:text-6xl lg:text-[5.2rem] mb-8" itemprop="name">
+      <h1 class="display display-italic text-[2.6rem] sm:text-5xl md:text-6xl lg:text-[5.2rem] mb-8">
         {{ .Title }}
       </h1>
 
@@ -97,7 +97,7 @@
 
         {{ with .Params.summary }}
         <span class="mono-label self-start mt-1">Brief</span>
-        <p class="font-[family-name:var(--font-body)] text-lg leading-snug text-[color:var(--color-paper-dim)] italic" itemprop="description">
+        <p class="font-[family-name:var(--font-body)] text-lg leading-snug text-[color:var(--color-paper-dim)] italic">
           {{ . }}
         </p>
         {{ end }}


### PR DESCRIPTION
## Summary

Adds JSON-LD structured data alongside the existing microdata. 2 files, +106 / −0.

JSON-LD is Google's preferred format for structured data — better snippets in search results, easier disambiguation for AI scrapers (Perplexity, ChatGPT, etc.), and richer signals for the Knowledge Graph.

### What it emits, per page kind

| URL pattern         | schema.org `@type` | Key fields                                                                 |
| ------------------- | ------------------ | -------------------------------------------------------------------------- |
| `/`                 | `WebSite`          | name, url, description, inLanguage, publisher (Person)                     |
| `/authors/<slug>/`  | `Person`           | name, jobTitle (current `career` entry), image (avatar), address, sameAs (GitHub / Mastodon / Twitter / LinkedIn / YouTube), description |
| `/talk/<slug>/`     | `Event`            | name, startDate, endDate, eventStatus, eventAttendanceMode (offline by default), location (Place), organizer (Organization with `event_url`), performer, description |
| `/reader/<slug>/`   | `Article`          | headline, datePublished/Modified, image, inLanguage, author, publisher     |
| `/post/<slug>/`     | `Article`          | …same as Reader; plus optional `keywords` from page tags                   |
| `/courses/<…>/`     | `Article`          | course chapters                                                            |

All other pages (taxonomies, archives) intentionally skip JSON-LD.

### Implementation

- Single branching partial `layouts/partials/jsonld.html` decides the schema by `.IsHome` / `.Section` / `.Type`.
- Wired into `layouts/partials/head.html` so every page gets the right `<script type="application/ld+json">` automatically.
- **Bug found & fixed during build**: Go's `html/template` auto-escapes content inside `<script>` tags as a JS string literal, which double-encoded the JSON. Fixed by piping `jsonify` output through `safeJS` so the JSON object renders verbatim.

## Test plan

- [x] `make css && hugo` builds cleanly.
- [x] Each page kind emits the expected `@type` (validated with `jq`):
  - `/` → `WebSite` / "Prskavec.Net"
  - `/authors/abtris/` → `Person` / "Ladislav Prskavec"
  - `/talk/2025-04-23-cloudnative/` → `Event` / "From Small Terraform Projects to Terralith" / startDate 2025-04-23T18:00:00Z
  - `/post/schema_first_telemetry/` → `Article` / "Schema-First Telemetry in Go…"
  - `/reader/2026-05-27-webexpo/` → `Article` / "Under the Hood of AI"
  - `/courses/how-to-make-oncall/chapter01/` → `Article` / "Roster"
- [x] All JSON parses cleanly (no double-encoding regression).
- [ ] Validate with Google's [Rich Results Test](https://search.google.com/test/rich-results) once deployed.
- [ ] Validate with [Schema Markup Validator](https://validator.schema.org/) once deployed.