### PR TITLE
Deslop WebExpo 2026 MCP talk and reader write-up

### DIFF
--- a/content/reader/2026-05-27-webexpo/index.md
+++ b/content/reader/2026-05-27-webexpo/index.md
@@ -4,7 +4,7 @@ subtitle: "Building Your Own MCP Server in Go"
 author: "Ladislav Prskavec — WebExpo Prague 2026"
 date: "2026-05-27T11:00:00Z"
 lastmod: "2026-05-27T12:00:00Z"
-summary: "A reader-friendly write-up of my WebExpo Prague 2026 talk on building your own Model Context Protocol (MCP) server in Go — what MCP is, why it matters, how to design it well, and the security boundaries you need before letting an AI touch your production systems."
+summary: "A reader-friendly write-up of my WebExpo Prague 2026 talk on building your own Model Context Protocol (MCP) server in Go: what MCP is, why it matters, how to design it well, and the security boundaries you need before letting an AI touch your production systems."
 draft: false
 talk: "/talk/2026-05-27-webexpo/"
 ---
@@ -13,22 +13,22 @@ talk: "/talk/2026-05-27-webexpo/"
 
 ---
 
-Everyone uses AI daily — ChatGPT, Copilot, Claude. But how many of us have *extended* an AI model? Given it a new capability it didn't have before? That's what this talk is about: building your own MCP server.
+Everyone uses AI daily: ChatGPT, Copilot, Claude. But how many of us have *extended* an AI model? Given it a new capability it didn't have before? That's what this talk is about: building your own MCP server.
 
 I'm Ladislav Prskavec, Staff Engineer at [Everpure](https://everpure.com). I mostly work with Go, Kubernetes, and cloud (AWS, OCI, Azure). I organize the Prague Go Meetup and co-host the *You Build It, You Run It* podcast.
 
-This isn't only for infrastructure people. The concepts apply whether you write JavaScript, Python, Ruby — anything. I chose Go because I think AI writes clean Go (and I'll show you why), but you can follow along in your own language.
+This isn't only for infrastructure people. The concepts apply whether you write JavaScript, Python, Ruby, or anything. I chose Go because I think AI writes clean Go (and I'll show you why), but you can follow along in your own language.
 
-## AI Is Powerful — But Blind
+## AI Is Powerful but Blind
 
-GPT-4, Claude, Gemini — they can reason about almost anything. But they're completely blind to *your* world.
+GPT-4, Claude, and Gemini can reason about almost anything. But they're completely blind to *your* world.
 
 They don't know what's in your database. They can't check if your deploy went through. They can't look at your error logs. They're incredibly smart, but incredibly isolated.
 
-- They can't query your **database** — imagine asking AI "how many users signed up this week?" and it just knows.
-- They can't access your **CMS or user data** — what if AI could search your docs, update a blog post, check content status?
-- They can't search your **project documentation** — every project has that one wiki page nobody can find. AI could find it instantly.
-- They can't call your **internal APIs** — microservices, webhooks, admin endpoints. AI can't touch any of them.
+- They can't query your **database**. Imagine asking AI "how many users signed up this week?" and it just knows.
+- They can't access your **CMS or user data**. What if AI could search your docs, update a blog post, check content status?
+- They can't search your **project documentation**. Every project has that one wiki page nobody can find; AI could find it instantly.
+- They can't call your **internal APIs**: microservices, webhooks, admin endpoints. AI can't touch any of them.
 
 That gap between AI's intelligence and your data is what we're going to bridge.
 
@@ -38,7 +38,7 @@ That gap between AI's intelligence and your data is what we're going to bridge.
 
 This isn't theoretical. In November 2025, Grafana Labs published a [case study](https://grafana.com/blog/2025/11/17/a-tale-of-two-incident-responses-how-our-ai-assist-helped-us-find-the-cause-3-5x-faster/) where they connected AI to their observability stack.
 
-During an incident, the AI assistant found the root cause **3.5× faster** than the human-only team. Not because the humans were slow — because the AI could search across all their data simultaneously. Human engineers took 28 minutes. The AI assistant took 8.
+During an incident, the AI assistant found the root cause **3.5× faster** than the human-only team. Not because the humans were slow, but because the AI could search across all their data simultaneously. Human engineers took 28 minutes. The AI assistant took 8.
 
 Here's the ironic twist: the bug was caused by AI-generated code. A SQL query that an AI wrote passed code review, worked fine in staging, but caused an unbounded join in production. And AI-powered tools found it.
 
@@ -46,7 +46,7 @@ Now imagine that for *your* domain. AI that knows your schema, your business log
 
 ## MCP: The Model Context Protocol
 
-**MCP** stands for Model Context Protocol. It's a standard originally created by Anthropic and now governed by the Linux Foundation. It defines how an AI client talks to external tools — JSON-RPC over stdio or Server-Sent Events.
+**MCP** stands for Model Context Protocol. It's a standard originally created by Anthropic and now governed by the Linux Foundation. It defines how an AI client talks to external tools, using JSON-RPC over stdio or Server-Sent Events.
 
 You don't need to care about the wire protocol. What matters is the framing:
 
@@ -64,18 +64,18 @@ The best analogy I've heard: MCP is USB for AI.
 | Fragile connections   | Secure, typed APIs   |
 | One-off scripts       | Reusable servers     |
 
-Before MCP, every AI integration was custom. You'd hack together a function-calling wrapper, deal with auth, handle errors yourself. After MCP, there's a standard protocol — you build a server once and it works with Claude, with VS Code, with any MCP-compatible client.
+Before MCP, every AI integration was custom. You'd hack together a function-calling wrapper, deal with auth, handle errors yourself. After MCP, there's a standard protocol: you build a server once and it works with Claude, with VS Code, with any MCP-compatible client.
 
-Build once, use with **any** AI client.
+Build once, use with any AI client.
 
 ## What Can You Connect?
 
-- **Databases** — query Postgres, SQLite, MongoDB in natural language
-- **CMS** — search and update content
-- **Deployments** — check status, trigger builds
-- **Tests** — run and analyze test results
-- **Analytics** — pull metrics and dashboards
-- **Logs** — search across your stack
+- **Databases**: query Postgres, SQLite, MongoDB in natural language
+- **CMS**: search and update content
+- **Deployments**: check status, trigger builds
+- **Tests**: run and analyze test results
+- **Analytics**: pull metrics and dashboards
+- **Logs**: search across your stack
 
 If it has an API, you can connect it. That's the beauty of MCP.
 
@@ -83,20 +83,20 @@ If it has an API, you can connect it. That's the beauty of MCP.
 
 ![MCP architecture: AI Host talks to an MCP Server over JSON-RPC; the server talks to your tools (database, REST API, files, Kubernetes)](assets/mcp-architecture.svg)
 
-The architecture is dead simple. On one side, your AI host — Claude Desktop, VS Code, whatever MCP client you use. On the other side, your MCP server — a small program you write.
+The architecture is dead simple. On one side, your AI host: Claude Desktop, VS Code, whatever MCP client you use. On the other side, your MCP server, a small program you write.
 
-They talk over JSON-RPC. The transport is usually stdio — your server reads from stdin and writes to stdout. Or SSE for remote servers.
+They talk over JSON-RPC. The transport is usually stdio: your server reads from stdin and writes to stdout. Or SSE for remote servers.
 
-Your MCP server then talks to whatever you want — a database, a REST API, a file system, a Kubernetes cluster. That's it. No complex middleware, no message queues. Just a small server that translates between AI and your tools.
+Your MCP server then talks to whatever you want: a database, a REST API, a file system, a Kubernetes cluster. That's it. No complex middleware, no message queues. Just a small server that translates between AI and your tools.
 
 ## Any Language, Not Just Go
 
 Before I dive into Go: you can build this in *any* language.
 
-- **TypeScript** — official SDK from Anthropic, `@modelcontextprotocol/sdk`
-- **Python** — `mcp` package
-- **Go** — `mcp-go`
-- **Rust**, **Java**, **C#** — and more
+- **TypeScript**: official SDK from Anthropic, `@modelcontextprotocol/sdk`
+- **Python**: `mcp` package
+- **Go**: `mcp-go`
+- **Rust**, **Java**, **C#**, and more
 
 I chose Go for reasons I'll explain next, but if you're a TypeScript dev, you can follow the same patterns with the TS SDK. The protocol is the same.
 
@@ -107,11 +107,11 @@ Four reasons, and the last one might surprise you.
 1. **Single binary.** `go build` and you get one file. No `node_modules`, no virtual environments. Copy it anywhere, it runs.
 2. **Fast startup.** MCP servers launch per-session. Sub-millisecond startup means your AI doesn't wait.
 3. **Great concurrency.** If your server exposes multiple tools, Go handles concurrent requests beautifully with goroutines.
-4. **AI writes clean Go.** This one surprised me. I think it's because Go is simple and opinionated — there's usually one way to do things, so AI models converge on good code.
+4. **AI writes clean Go.** This one surprised me. I think it's because Go is simple and opinionated: there's usually one way to do things, so AI models converge on good code.
 
 ## Before We Cook: Principles + Guardrails
 
-Before we dive into the demo, here are the two things I want you to watch for as I build — the design principles I'll be applying, and the security guardrails I'll be checking.
+Before we dive into the demo, here are the two things I want you to watch for as I build: the design principles I'll be applying, and the security guardrails I'll be checking.
 
 ### Design Principles
 
@@ -133,7 +133,7 @@ The five common mistakes to avoid:
 
 ![Three pillars: Discovery (minimize token footprint), Iteration (minimize turns to finish), Context (all signal, no noise)](assets/design-pillars.svg)
 
-Lowin's three pillars — your design checklist:
+Lowin's three pillars, your design checklist:
 
 - **Discovery.** Minimize token footprint. Every tool description costs tokens. Be concise but clear.
 - **Iteration.** Minimize turns to finish a task. If it takes 5 calls to do something simple, redesign it.
@@ -145,7 +145,7 @@ monday.com put it well: think of MCP as **UI replacement**, not API wrapper.
 
 Two independent 2026 studies say no.
 
-[Hasan et al.](https://arxiv.org/abs/2602.14878) analyzed **856 tools** across 103 MCP servers and found **97.1% have at least one description smell** — missing purpose, vague parameters, no examples. [Wang et al.](https://arxiv.org/abs/2602.18914) looked at **10,831 servers** and found **73% have duplicate tool names**. In a head-to-head arena where five servers with identical code competed for the agent's pick, the one with a standard-compliant description was selected **+260% more often** (p<0.01).
+[Hasan et al.](https://arxiv.org/abs/2602.14878) analyzed **856 tools** across 103 MCP servers and found **97.1% have at least one description smell**: missing purpose, vague parameters, no examples. [Wang et al.](https://arxiv.org/abs/2602.18914) looked at **10,831 servers** and found **73% have duplicate tool names**. In a head-to-head arena where five servers with identical code competed for the agent's pick, the one with a standard-compliant description was selected **+260% more often** (p<0.01).
 
 Same code. Better description. Wins more.
 
@@ -156,7 +156,7 @@ It's not just academia. Anthropic's own [Advanced Tool Use](https://www.anthropi
 Their good example reads like a sentence: *"Search for customer orders by date range, status, or total amount."*
 Their poor example reads like a UNIX flag: *"Execute order query."*
 
-Same tool. Same code behind it. One gets called; the other gets skipped. Academic researchers and the model vendor converge independently on the same prescription — that's the signal worth trusting.
+Same tool. Same code behind it. One gets called; the other gets skipped. Academic researchers and the model vendor converge independently on the same prescription, and that's the signal worth trusting.
 
 ### Two Paths to Better AgentEx
 
@@ -168,49 +168,49 @@ Before the demo, one honest framing: there are *two* paths to better agent exper
 | **+260%** selection lift (Wang) | **99.9%** fewer tokens (Cloudflare, 2,500 endpoints) |
 | **72% → 90%** accuracy (Anthropic) | LLM writes code, not picks tools |
 
-Anthropic, Cloudflare, and [Jeremiah Lowin](https://www.prefect.io/blog/code-mode-the-better-way-to-use-mcp) himself — the same person quoted on the principles slide — all argue that for large APIs, you should expose just `search()` and `execute()` meta-tools and let the LLM write code against them. Cloudflare's number: 2,500 endpoints, 99.9% fewer tokens.
+Anthropic, Cloudflare, and [Jeremiah Lowin](https://www.prefect.io/blog/code-mode-the-better-way-to-use-mcp) himself, the same person quoted on the principles slide, all argue that for large APIs, you should expose just `search()` and `execute()` meta-tools and let the LLM write code against them. Cloudflare's number: 2,500 endpoints, 99.9% fewer tokens.
 
 Both paths agree on the through-line: **products for agents, not APIs for humans.** They disagree on whether you invest at the description layer or the protocol layer. In the demo, we apply path one. Code Mode comes back in *Emerging Patterns*.
 
 ### Demo Guardrails
 
-Three security checks I'll apply as I build — watch for them in the security part of the demo:
+Three security checks I'll apply as I build, watch for them in the security part of the demo:
 
 1. **Validate every argument.** Treat LLM input as untrusted, always.
 2. **Allow-list, not deny-list.** Explicit boundaries on what tools can touch.
 3. **Fail closed.** Anything ambiguous gets blocked.
 
-These map directly to OWASP Agentic Top 10 (2026) — **ASI01** (Goal Hijack) and **ASI02** (Tool Misuse). The full breach stories and complete checklist come after the demo.
+These map directly to OWASP Agentic Top 10 (2026): **ASI01** (Goal Hijack) and **ASI02** (Tool Misuse). The full breach stories and complete checklist come after the demo.
 
 ## Demo Recap
 
 {{< video src="assets/demo-master.mp4" poster="assets/demo-poster.jpg" >}}
 
-In the talk I walked through a recorded build of a brand-new tool on top of an existing MCP server — about **10 minutes** of actual build time, with an AI assistant writing the code.
+In the talk I walked through a recorded build of a brand-new tool on top of an existing MCP server, about **10 minutes** of actual build time, with an AI assistant writing the code.
 
 The flow:
 
 1. Walked through the repo structure (~500 lines total, not complex).
-2. Showed an existing tool — the pattern is just a function with input validation and a return format.
+2. Showed an existing tool: the pattern is just a function with input validation and a return format.
 3. Asked the AI assistant to add a `git_status` tool, watching it write the code live.
 4. Wired it up with minimal boilerplate, built with `go build`.
 5. Tested with [MCP Inspector](https://github.com/modelcontextprotocol/inspector) before connecting to a real AI client.
-6. Demonstrated allowed vs blocked requests — the security demo.
+6. Demonstrated allowed vs blocked requests: the security demo.
 
 The point isn't that I'm fast. It's that this is simple. An MCP tool is just a function with a description. The protocol handles everything else.
 
-Full demo code on GitHub: **[github.com/abtris/mcp-server-example](https://github.com/abtris/mcp-server-example)**. The recorded walkthrough is a stripped slice — the repo goes further:
+Full demo code on GitHub: **[github.com/abtris/mcp-server-example](https://github.com/abtris/mcp-server-example)**. The recorded walkthrough is a stripped slice; the repo goes further:
 
-- **CLI** — flags and subcommands for ergonomic local use
+- **CLI**: flags and subcommands for ergonomic local use
 - **Logs, metrics, traces**
 - **Updated to the latest MCP Go SDK**
-- **Better structure** — separate packages with clear boundaries
-- **GitHub Actions** — CI on every push
-- **Separate config** — env-based, not hardcoded
+- **Better structure**: separate packages with clear boundaries
+- **GitHub Actions**: CI on every push
+- **Separate config**: env-based, not hardcoded
 
 ## Security in Detail: Real Breaches, Real Defenses
 
-You've seen the guardrails applied in the demo. Now let me show you why they matter — what actually happens when you skip them.
+You've seen the guardrails applied in the demo. Now let me show you why they matter: what actually happens when you skip them.
 
 If you're giving AI the ability to query your database, call your APIs, or read your files, you need to think about what happens when things go wrong. Because they will.
 
@@ -218,13 +218,13 @@ If you're giving AI the ability to query your database, call your APIs, or read 
 
 ![Simon Willison's lethal trifecta: private data + untrusted content + external communication = trivial data exfiltration](assets/lethal-trifecta.svg)
 
-Simon Willison — who coined the term *prompt injection* — identified what he calls the **lethal trifecta**. When all three are present, trivial data theft becomes possible:
+Simon Willison, who coined the term *prompt injection*, identified what he calls the **lethal trifecta**. When all three are present, trivial data theft becomes possible:
 
 1. **Access to private data.** That's the whole point of connecting MCP to your systems.
 2. **Exposure to untrusted content.** Any attacker-controlled text entering the LLM context.
 3. **External communication ability.** Any way to exfiltrate information.
 
-MCP makes it easy to accidentally assemble this combination. You **must** think about it.
+MCP makes it easy to accidentally assemble this combination. You must think about it.
 
 > Once data enters an LLM's context window, your ability to secure it is functionally gone.
 >
@@ -232,14 +232,14 @@ MCP makes it easy to accidentally assemble this combination. You **must** think 
 
 ## A Real Breach: GitHub MCP Server
 
-This isn't theoretical. **May 2025** — Invariant Labs disclosed a working attack against the *official* GitHub MCP server. 14,000 stars on GitHub at the time.
+This isn't theoretical. **May 2025**: Invariant Labs disclosed a working attack against the *official* GitHub MCP server. 14,000 stars on GitHub at the time.
 
 The attack chain:
 
 1. An attacker files a malicious **public** issue. The instructions are hidden in plain markdown.
 2. A developer asks their AI assistant something innocent: *"check the open issues."*
 3. The agent reads the issue and gets **prompt-injected**.
-4. The agent calls a legitimate tool — `list_issues`, then private repo reads — and exfiltrates data back into a public issue.
+4. The agent calls a legitimate tool (`list_issues`, then private repo reads) and exfiltrates data back into a public issue.
 
 No malware. No stolen credentials. Just natural language instructions hidden in plain sight.
 
@@ -249,7 +249,7 @@ This maps cleanly onto the [OWASP Top 10 for Agentic Applications (2026)](https:
 - **ASI02** Tool Misuse
 - **ASI03** Privilege Abuse
 
-All three legs of the trifecta were present. There's also **CVE-2025-6514** in `mcp-remote` — CVSS 9.6, full RCE on Claude Desktop and Cursor. Supply chain matters too.
+All three legs of the trifecta were present. There's also **CVE-2025-6514** in `mcp-remote`: CVSS 9.6, full RCE on Claude Desktop and Cursor. Supply chain matters too.
 
 Sources: [Docker blog](https://www.docker.com/blog/mcp-horror-stories-github-prompt-injection/) · [OWASP Agentic Top 10](https://genai.owasp.org/resource/owasp-top-10-for-agentic-applications-for-2026/).
 
@@ -284,7 +284,7 @@ You don't need all of these on day one. But you need **input validation** and **
 
 **Key principle: never run your MCP server as root. Treat every argument from the LLM as untrusted.**
 
-MCP standardizes how things *connect*, not whether they *should*. Security is your job — and now there's a framework (OWASP Agentic Top 10 2026) that tells you exactly what to look for.
+MCP standardizes how things *connect*, not whether they *should*. Security is your job, and now there's a framework (OWASP Agentic Top 10 2026) that tells you exactly what to look for.
 
 ## When Does MCP Make Sense?
 
@@ -294,21 +294,21 @@ I want to be honest: MCP is great, but it's not always the right answer. There's
 >
 > — [Eric Holmes](https://ejholmes.github.io/2026/02/28/mcp-is-dead-long-live-the-cli.html)
 
-One [analysis](https://kanyilmaz.me/2026/02/23/cli-vs-mcp.html) showed CLI can be **94% cheaper** — fewer tokens, faster execution, less overhead.
+One [analysis](https://kanyilmaz.me/2026/02/23/cli-vs-mcp.html) showed CLI can be **94% cheaper**: fewer tokens, faster execution, less overhead.
 
 So why use MCP at all? Because it wins when you need:
 
-- **Tool discovery** — self-describing schemas. CLI requires the agent to already know the commands.
-- **Security boundaries** — explicit per-tool permissions. CLI gives full shell access.
-- **Remote execution** — MCP works natively with remote servers. CLI is local unless you set up SSH.
-- **Cross-platform consistency** — MCP is the same everywhere. CLI differs between macOS, Linux, Windows.
+- **Tool discovery**: self-describing schemas. CLI requires the agent to already know the commands.
+- **Security boundaries**: explicit per-tool permissions. CLI gives full shell access.
+- **Remote execution**: MCP works natively with remote servers. CLI is local unless you set up SSH.
+- **Cross-platform consistency**: MCP is the same everywhere. CLI differs between macOS, Linux, Windows.
 
 ## Decision Framework
 
 ![Decision framework: local + simple + trusted shell → CLI; needs discovery, permissions, audit, or remote → MCP; Code Mode sits in between](assets/cli-vs-mcp-decision.svg)
 
-- If the tool is local, simple, and the agent already has trusted shell access — consider CLI.
-- If the capability needs discovery, permissions, audit, remote execution, or reuse across clients — MCP shines.
+- If the tool is local, simple, and the agent already has trusted shell access, consider CLI.
+- If the capability needs discovery, permissions, audit, remote execution, or reuse across clients, MCP shines.
 - **Code Mode** can sit between them: local scripts for speed, MCP for durable service capabilities.
 
 The answer isn't *always MCP* or *never MCP*. It's *use the right tool for the job*.
@@ -332,7 +332,7 @@ Concrete example: a Skill might say *"When debugging production issues, check lo
 
 Four concrete scenarios where MCP really shines:
 
-- **Developer experience.** AI that knows your codebase, your schema, your test structure. Not generic AI — AI that understands *your* project.
+- **Developer experience.** AI that knows your codebase, your schema, your test structure. Not generic AI, but AI that understands *your* project.
 - **Exploration.** *"Find all failing tests and suggest fixes."* That's a multi-tool workflow: run tests, read failing files, read source, suggest changes. MCP orchestrates this naturally.
 - **Integration.** Connecting multiple systems in one conversation. *"Check the deploy status in CI, look at the error rate in monitoring, check the latest commits."* Three APIs, one conversation.
 - **Onboarding.** Underrated. A new developer joins and asks AI about your project: *"How do we run migrations? Where's the auth module? What's the testing pattern?"* If your MCP server exposes docs, code search, and schema tools, onboarding becomes magical.
@@ -341,14 +341,14 @@ Four concrete scenarios where MCP really shines:
 
 Before we wrap up: MCP isn't going anywhere.
 
-In late 2025, MCP transitioned from Anthropic to the **Linux Foundation** — specifically the Agentic AI Foundation (AAIF). This means open governance, working groups, proper RFC processes. It's now permanent open infrastructure.
+In late 2025, MCP transitioned from Anthropic to the **Linux Foundation**, specifically the Agentic AI Foundation (AAIF). This means open governance, working groups, proper RFC processes. It's now permanent open infrastructure.
 
 The 2026 roadmap is delivering. The `2026-07-28` release candidate was locked on May 21, 2026; the final specification ships July 28:
 
-- **Stateless protocol** — the `Mcp-Session-Id` header and `initialize` handshake are gone; any request can land on any server instance
+- **Stateless protocol**: the `Mcp-Session-Id` header and `initialize` handshake are gone; any request can land on any server instance
 - A **Tasks** extension for long-running operations (handle-based; poll or stream progress)
 - **SSO** integration and audit trails
-- Improved security with **DPoP** — secretless, short-lived access tokens
+- Improved security with **DPoP**: secretless, short-lived access tokens
 
 This isn't a side project anymore. It's foundational infrastructure.
 
@@ -359,28 +359,28 @@ This isn't a side project anymore. It's foundational infrastructure.
 - **Code Mode.** Instead of defining 40 individual tools that bloat the context window, expose meta-tools that execute scripts. The agent writes Python or Starlark; the server runs it. 50% token reduction, 40% faster.
 - **MCP Apps.** Tools that return interactive HTML in sandboxed iframes. Imagine a Gantt chart that updates as you discuss project timelines. Collaborative UI between agent and human. Promoted into the July RC.
 - **Tasks.** Long-running operations as a first-class pattern. The server returns a handle; the client polls or streams progress. Just promoted from experimental core to a proper extension in the RC.
-- **Elicitation.** The server pauses to ask the human for input — OAuth credentials, confirmation for high-impact operations. Keeps human-in-the-loop for sensitive tasks.
+- **Elicitation.** The server pauses to ask the human for input: OAuth credentials, confirmation for high-impact operations. Keeps human-in-the-loop for sensitive tasks.
 
 These patterns are emerging now. By 2027, they'll be standard.
 
 ## Inspiration: Community MCP Servers
 
-- **Database explorer** — natural language SQL across Postgres, MySQL, SQLite
-- **GitHub** — PR reviews, issue triage, repo search
-- **Sentry / BetterStack** — error investigation across your error tracking
-- **Zotero** — search your research library *(I built [this one](https://github.com/abtris/zotero-mcp-go-server) myself; the [Go client](https://github.com/abtris/zotero-go-client) is open source too)*
-- **Kubernetes** — cluster status
+- **Database explorer**: natural language SQL across Postgres, MySQL, SQLite
+- **GitHub**: PR reviews, issue triage, repo search
+- **Sentry / BetterStack**: error investigation across your error tracking
+- **Zotero**: search your research library *(I built [this one](https://github.com/abtris/zotero-mcp-go-server) myself; the [Go client](https://github.com/abtris/zotero-go-client) is open source too)*
+- **Kubernetes**: cluster status
 
 Browse hundreds more at [mcpservers.org](https://mcpservers.org). You'll find things you didn't know you needed.
 
-Or — and this is what I hope you take away — **build your own**. It took us 10 minutes in the demo. It took me an afternoon for Zotero. You can do this.
+Or, and this is what I hope you take away, build your own. It took us 10 minutes in the demo. It took me an afternoon for Zotero. You can do this.
 
 ## Getting Started
 
 Five steps. That's it.
 
 1. **Pick a use case.** What data does your AI not have access to today? What question do you wish you could ask it? That's your first tool.
-2. **Choose your language.** Go, TypeScript, Python — they all have SDKs. Use what you know.
+2. **Choose your language.** Go, TypeScript, Python all have SDKs. Use what you know.
 3. **Start small.** One tool. One server. Don't try to build the "everything MCP server."
 4. **Test with MCP Inspector.** `npx @modelcontextprotocol/inspector`. Free, invaluable for debugging without a real AI client.
 5. **Add security.** At minimum, validate inputs and log everything. Add more as needed.
@@ -389,14 +389,14 @@ You can have a working MCP server in under an hour. I'm not exaggerating.
 
 ## Resources
 
-- **These slides** — [speakerdeck.com/abtris/webexpo-2026](https://speakerdeck.com/abtris/webexpo-2026)
-- **MCP Spec** — [modelcontextprotocol.io](https://modelcontextprotocol.io)
-- **Demo repo** — [github.com/abtris/mcp-server-example](https://github.com/abtris/mcp-server-example)
-- **MCP Inspector** — `npx @modelcontextprotocol/inspector`
-- **Security primer** — [authzed.com/blog/mcp-is-not-secure](https://authzed.com/blog/mcp-is-not-secure)
-- **GitHub heist writeup** — [docker.com/blog/mcp-horror-stories-github-prompt-injection](https://www.docker.com/blog/mcp-horror-stories-github-prompt-injection/)
-- **OWASP Agentic Top 10 (2026)** — [genai.owasp.org](https://genai.owasp.org/resource/owasp-top-10-for-agentic-applications-for-2026/)
-- **MCP directory** — [mcpservers.org](https://mcpservers.org)
+- **These slides**: [speakerdeck.com/abtris/webexpo-2026](https://speakerdeck.com/abtris/webexpo-2026)
+- **MCP Spec**: [modelcontextprotocol.io](https://modelcontextprotocol.io)
+- **Demo repo**: [github.com/abtris/mcp-server-example](https://github.com/abtris/mcp-server-example)
+- **MCP Inspector**: `npx @modelcontextprotocol/inspector`
+- **Security primer**: [authzed.com/blog/mcp-is-not-secure](https://authzed.com/blog/mcp-is-not-secure)
+- **GitHub heist writeup**: [docker.com/blog/mcp-horror-stories-github-prompt-injection](https://www.docker.com/blog/mcp-horror-stories-github-prompt-injection/)
+- **OWASP Agentic Top 10 (2026)**: [genai.owasp.org](https://genai.owasp.org/resource/owasp-top-10-for-agentic-applications-for-2026/)
+- **MCP directory**: [mcpservers.org](https://mcpservers.org)
 
 ## Go Build Something
 
@@ -406,7 +406,7 @@ It could be querying your database. Searching your docs. Checking your deploy st
 
 You saw how fast it is. An afternoon. Maybe less.
 
-And when you do — share it. Open source it. Add it to [mcpservers.org](https://mcpservers.org). The ecosystem grows when we all contribute.
+And when you do, share it. Open source it. Add it to [mcpservers.org](https://mcpservers.org). The ecosystem grows when we all contribute.
 
 ---
 
@@ -414,7 +414,7 @@ And when you do — share it. Open source it. Add it to [mcpservers.org](https:/
 
 **Can I use MCP with ChatGPT / OpenAI?**
 
-Yes. OpenAI has adopted MCP support — it works with ChatGPT Desktop and the API. The protocol is the same, so your server works with any compliant client.
+Yes. OpenAI has adopted MCP support; it works with ChatGPT Desktop and the API. The protocol is the same, so your server works with any compliant client.
 
 **Is MCP production-ready?**
 
@@ -422,7 +422,7 @@ The spec is evolving but stable enough for production. Grafana, Cloudflare, and 
 
 **How is this different from function calling?**
 
-Function calling is built into the AI model API — you define functions the model can call. MCP is a protocol layer between the AI client and external tools. MCP servers are **reusable across clients**; function calling is tied to one API. Think of MCP as a standardized way to do function calling that works everywhere.
+Function calling is built into the AI model API: you define functions the model can call. MCP is a protocol layer between the AI client and external tools. MCP servers are **reusable across clients**; function calling is tied to one API. Think of MCP as a standardized way to do function calling that works everywhere.
 
 **What about latency? Does MCP slow things down?**
 
@@ -438,12 +438,12 @@ Actively being worked on in the spec. Current draft adds OAuth support. For now,
 
 **Should I use Skills or MCP?**
 
-Both. Skills teach the agent *how* to use tools — knowledge and workflows. MCP gives the agent *access* to tools it couldn't otherwise reach. A Skill might say "always check logs before metrics when debugging"; an MCP server is what actually connects the agent to your logs.
+Both. Skills teach the agent *how* to use tools: knowledge and workflows. MCP gives the agent *access* to tools it couldn't otherwise reach. A Skill might say "always check logs before metrics when debugging"; an MCP server is what actually connects the agent to your logs.
 
 **How do I test an MCP server?**
 
-Three layers. **One:** contract tests using the MCP SDK — verifies your server follows the protocol. **Two:** MCP Inspector for manual exploration. **Three:** for production-grade testing, statistical frameworks like Tenkai measure impact across multiple runs, because LLM interactions are non-deterministic. Running once isn't enough.
+Three layers. **One:** contract tests using the MCP SDK, which verify your server follows the protocol. **Two:** MCP Inspector for manual exploration. **Three:** for production-grade testing, statistical frameworks like Tenkai measure impact across multiple runs, because LLM interactions are non-deterministic. Running once isn't enough.
 
 ---
 
-*Thanks for reading. If you build something, I'd love to hear about it — [@abtris](https://twitter.com/abtris) · [github.com/abtris](https://github.com/abtris) · [You Build It, You Run It Podcast](https://ybyr.net).*
+*Thanks for reading. If you build something, I'd love to hear about it: [@abtris](https://twitter.com/abtris) · [github.com/abtris](https://github.com/abtris) · [You Build It, You Run It Podcast](https://ybyr.net).*

--- a/content/talk/2026-05-27-WebExpo/index.md
+++ b/content/talk/2026-05-27-WebExpo/index.md
@@ -4,7 +4,7 @@ event: WebExpo Prague 2026
 event_url: https://webexpo.net/prague2026/sessions/under-the-hood-of-ai-building-your-own-mcp-server-in-go/
 venue: Lucerna Cinema
 location: Prague, Czech Republic
-summary: "Everyone talks about using AI models, but few developers know how to extend them. In this talk, we go one level deeper and build our own Model Context Protocol (MCP) server in Go. MCP is an emerging standard that lets AI systems securely access tools, APIs, and real-world data. You'll see how to design a minimal, production-ready MCP service, connect it to an AI client, and expose your own capabilities - from querying observability data to automating workflows. We will extend the capabilities of our coding agent with an MCP server to help us in the future."
+summary: "Most developers use AI models, but few extend them. In this talk we go a level deeper and build our own Model Context Protocol (MCP) server in Go. MCP is an emerging standard that lets AI systems securely reach tools, APIs, and real-world data. I show how to build a small, working MCP service, connect it to an AI client, and expose your own capabilities, from querying observability data to automating workflows. By the end we extend our own coding agent with an MCP server so it can do more for us."
 
 # Talk start and end times.
 #   End time can optionally be hidden by prefixing the line with `#`.
@@ -55,9 +55,9 @@ projects:
 math: false
 ---
 
-Everyone talks about using AI models, but few developers know how to extend them. In this talk, we go one level deeper and build our own Model Context Protocol (MCP) server in Go. We use one of the AI assistants (Claude, Augment, Gemini) to code it. You can use any language, but I think AI using Go is super good and I explain why.
+Most developers use AI models, but few extend them. In this talk we go a level deeper and build our own Model Context Protocol (MCP) server in Go, using an AI assistant (Claude, Augment, Gemini) to write the code. You can use any language, but I think AI is especially good at Go, and I explain why.
 
-MCP is an emerging standard that lets AI systems securely access tools, APIs, and real-world data. You'll see how to design a minimal, production-ready MCP service, connect it to an AI client, and expose your own capabilities - from querying observability data to automating workflows. We extend the capabilities of our coding agent with an MCP server to help us in the future.
+MCP is an emerging standard that lets AI systems securely reach tools, APIs, and real-world data. I show how to build a small, working MCP service, connect it to an AI client, and expose your own capabilities, from querying observability data to automating workflows. By the end we extend our own coding agent with an MCP server so it can do more for us.
 
 - Go
 - MCP


### PR DESCRIPTION
Deslop the WebExpo Prague 2026 MCP talk and its long-form reader write-up.

**Talk page** (`content/talk/2026-05-27-WebExpo`)
- Same fix as the Techspresso talk: dropped the "Everyone talks... but few" hook and "production-ready" inflation, replaced the spaced-hyphen dash with a comma. Facts, slides, and video links preserved.

**Reader write-up** (`content/reader/2026-05-27-webexpo`) — light pass only
- Reduced em-dashes from 89 to 4 (kept the four idiomatic quote/byline attributions), replacing the rest with commas, colons, periods, or parentheses as context fit.
- Trimmed two purely decorative inline bolds; kept bold on labels, numbers, and defined terms (they aid scanning in a talk write-up).
- Left all structure, tables, fragments, quotes, citations, numbers, and links untouched. Verified: every URL identical to before; all key figures intact (3.5x, 28 min, 856 tools, 97.1%, 10,831, 73%, +260%, 72% to 90%, CVE-2025-6514, CVSS 9.6, 94% cheaper, 2,500 endpoints, 2026-07-28, 14,000 stars).

This was deliberately a lighter touch than the blog-post PR: the content is dense and well-sourced, so only the stylistic AI tells were addressed.
