### PR TITLE
Polish homepage: accessibility, responsive nav, and design-system docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ test-results/
 
 # Tailwind build artifact (compiled by `make css` / Netlify build)
 static/css/output.css
+
+# Impeccable design-skill local state (hook cache, critique snapshots, sidecar)
+.impeccable/

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,230 @@
+---
+name: Prskavec.Net
+description: The personal site of an SRE — editorial type lit by a single incident-orange signal on a near-black ground.
+colors:
+  signal: "#ff5c2e"
+  signal-warm: "#ffae3a"
+  live: "#b8ff5c"
+  ink: "#0c0c0a"
+  ink-deep: "#050504"
+  paper: "#ede4d3"
+  paper-dim: "#8b8378"
+  paper-faint: "#857c6e"
+  rule: "#2a2823"
+  rule-bright: "#3a382f"
+typography:
+  display:
+    fontFamily: "Instrument Serif, Iowan Old Style, Georgia, serif"
+    fontSize: "clamp(2.8rem, 8vw, 6rem)"
+    fontWeight: 400
+    lineHeight: 0.98
+    letterSpacing: "0"
+  headline:
+    fontFamily: "Instrument Serif, Iowan Old Style, Georgia, serif"
+    fontSize: "2.5rem"
+    fontWeight: 400
+    lineHeight: 1.05
+    letterSpacing: "-0.015em"
+  title:
+    fontFamily: "Instrument Serif, Iowan Old Style, Georgia, serif"
+    fontSize: "1.875rem"
+    fontWeight: 400
+    lineHeight: 1.15
+    letterSpacing: "0"
+  body:
+    fontFamily: "Newsreader, Iowan Old Style, Georgia, serif"
+    fontSize: "1.2rem"
+    fontWeight: 400
+    lineHeight: 1.65
+    letterSpacing: "normal"
+  label:
+    fontFamily: "JetBrains Mono, ui-monospace, SF Mono, monospace"
+    fontSize: "0.875rem"
+    fontWeight: 500
+    lineHeight: 1.4
+    letterSpacing: "0.14em"
+rounded:
+  xs: "1px"
+  sm: "2px"
+  md: "4px"
+  lg: "6px"
+  full: "999px"
+spacing:
+  xs: "0.35rem"
+  sm: "0.7rem"
+  md: "1.5rem"
+  lg: "2rem"
+  section: "8rem"
+components:
+  button-primary:
+    backgroundColor: "{colors.signal}"
+    textColor: "{colors.ink}"
+    typography: "{typography.label}"
+    rounded: "{rounded.sm}"
+    padding: "0.7rem 1rem"
+  button-secondary:
+    backgroundColor: "transparent"
+    textColor: "{colors.paper}"
+    typography: "{typography.label}"
+    rounded: "{rounded.sm}"
+    padding: "0.7rem 1rem"
+  button-secondary-hover:
+    backgroundColor: "{colors.signal}"
+    textColor: "{colors.ink}"
+  chip:
+    backgroundColor: "transparent"
+    textColor: "{colors.paper-dim}"
+    typography: "{typography.label}"
+    rounded: "{rounded.sm}"
+    padding: "0.35rem 0.7rem"
+  chip-signal:
+    textColor: "{colors.signal}"
+  chip-live:
+    textColor: "{colors.live}"
+  card:
+    backgroundColor: "{colors.ink}"
+    textColor: "{colors.paper}"
+    rounded: "0"
+    padding: "2rem"
+  nav-link:
+    backgroundColor: "transparent"
+    textColor: "{colors.paper-dim}"
+    typography: "{typography.label}"
+  nav-link-active:
+    textColor: "{colors.paper}"
+---
+
+# Design System: Prskavec.Net
+
+## 1. Overview
+
+**Creative North Star: "The 3AM Console"**
+
+This is the screen an on-call engineer stares into when the pager goes off: a near-black surface where one incident-orange signal is the only thing that earns your eye. The system marries the discipline of a monitoring console — mono labels, ruled separators, a single alert color — with the calm authority of editorial typography. The serif headlines are the expert's voice; the orange is the thing that needs attention. Nothing glows that doesn't matter.
+
+The density is deliberate and confident. Surfaces are flat and matte, lit only by a faint film grain and two barely-there radial glows in the corners, like phosphor bleed on a dark display. Type does the heavy lifting: oversized Instrument Serif italics for the voice, a humanist Newsreader for long-form reading, and JetBrains Mono for every label, tag, and timestamp — the console annotations. Color is rationed. The whole palette is paper-on-ink plus exactly one saturated accent, so when the orange appears it reads as *signal*, never decoration.
+
+This system explicitly rejects the generic-SaaS landing page (gradient blobs, rounded-card grids, hero-metric templates, Inter-everywhere neutrality), the corporate-LinkedIn résumé (stock professionalism, badge walls, buzzword bullets), and the trend-chasing AI template (an eyebrow above every section, identical icon-heading-text card rows). Credibility here comes from craft and the work shown, not from claims. A visitor should wonder how it was built, not which tool built it.
+
+**Key Characteristics:**
+- Near-black ground (`ink` #0c0c0a), never a tinted near-white or cream.
+- Exactly one saturated accent (`signal` #ff5c2e — Incident Ember), rationed to ≤10% of any surface.
+- Three-voice typography: Instrument Serif display, Newsreader body, JetBrains Mono labels.
+- Flat by default; depth appears only as a response to state.
+- Atmosphere from film grain + corner radial glows, not from shadows or gradients-as-decoration.
+- Mono labels carry all metadata (dates, sections, tags) in tracked uppercase.
+
+## 2. Colors
+
+A monochromatic paper-on-ink ramp lit by a single incident-orange signal, with two rare functional accents (warm amber, live green).
+
+### Primary
+- **Incident Ember** (`#ff5c2e`): The one saturated color and the whole point of the palette. Used for the single thing that should draw the eye — hover/active states, link underlines, the drop-cap, the `:focus-visible` ring, the live-dot, key italic words in headlines. It is the signal in the noise; spend it sparingly.
+
+### Secondary
+- **Warm Amber** (`#ffae3a`): A rarer warm companion to the ember. Inline `code` text and search-result highlight `mark`. Signals "machine token" inside prose without competing with the primary ember.
+
+### Tertiary
+- **Live Green** (`#b8ff5c`): Strictly functional. The "upcoming / live / next on stage" status only — the pulsing live-dot and upcoming-talk chips. Never decorative; its presence means "happening soon."
+
+### Neutral
+- **Paper** (`#ede4d3`): The primary reading color on the dark ground (~10.5:1 on ink). All body text, headlines, and active labels.
+- **Paper Dim** (`#8b8378`): Secondary text — subheads, event names, muted labels, captions (~5.2:1 on ink; clears AA for body).
+- **Paper Faint** (`#857c6e`): The quietest legible tier — vertical marginalia, keyboard hints, colophon, the talk/post counts, the faded decorative numbers. Clears AA at ~4.8:1 on ink while staying a step below `paper-dim`, so it reads as "present but subordinate" without dropping below contrast.
+- **Ink** (`#0c0c0a`): The body ground. Near-black with the barest warm bias.
+- **Ink Deep** (`#050504`): A darker well for recessed surfaces — code blocks, media posters, the search panel backdrop.
+- **Rule** (`#2a2823`): The default hairline — borders, dividers, dashed list separators.
+- **Rule Bright** (`#3a382f`): The hover/emphasis border, one step up from rule.
+
+### Named Rules
+**The One Signal Rule.** Incident Ember appears on ≤10% of any screen. It marks the single thing that matters in that view — the next action, the live event, the active link. If two things are orange, neither reads as signal. Spend it like an alert, not like a brand color.
+
+**The No-Cream Rule.** The ground is `ink`, never a warm near-white. "Paper" is a text color here, not a background. Warmth comes from the ember and the type, never from tinting the surface toward beige.
+
+## 3. Typography
+
+**Display Font:** Instrument Serif (with Iowan Old Style, Georgia, serif)
+**Body Font:** Newsreader (with Iowan Old Style, Georgia, serif)
+**Label/Mono Font:** JetBrains Mono (with ui-monospace, SF Mono, monospace)
+
+**Character:** A high-contrast three-voice system. Instrument Serif is the dramatic, slightly theatrical display voice — used large and frequently in italic for emphasis. Newsreader is the workhorse: a warm, readable humanist serif for long-form. JetBrains Mono is the console annotation layer — every date, tag, section marker, and kbd hint. The pairing works because the two serifs sit at opposite ends of their scale (display drama vs. reading calm) and the mono provides a hard machine counterpoint to both.
+
+### Hierarchy
+- **Display** (Instrument Serif, 400, `clamp(2.8rem, 8vw, 6rem)`, lh 0.98): Hero headlines and section feature lines. Italic is used liberally for emphasis on key words, often in Incident Ember. Max caps at the 6rem (~96px) display ceiling; ratio 2.14× stays inside the ≤2.5× clamp bound.
+- **Headline** (Instrument Serif, 400, `2.5rem`, lh 1.05, ls -0.015em): In-article `h2`. Sets the prose rhythm.
+- **Title** (Instrument Serif, 400, `1.875rem`, lh 1.15): Talk-row titles, post-card titles, `h3`. The repeated "object title" voice across listings.
+- **Body** (Newsreader, 400, `1.2rem`, lh 1.65): Editorial prose. Capped at 68ch for readable measure; block elements (tables, code, images) span the full column.
+- **Label** (JetBrains Mono, 500, `0.875rem`, ls 0.14em, UPPERCASE): All metadata — section markers, dates, tags, nav links, vitals. The console layer. `0.875rem` is the floor; do not set mono labels smaller.
+
+### Named Rules
+**The Console-Annotation Rule.** Anything that is metadata — a date, a section name, a tag, a status, a keyboard hint — is set in JetBrains Mono, uppercase, tracked at 0.14em. Prose and headlines are never mono. This split is what makes the page read like an instrument.
+
+**The Italic-Emphasis Rule.** Emphasis in headlines is carried by Instrument Serif *italic* (and occasionally Incident Ember), never by bold or by a heavier weight. The display face has one weight; contrast comes from size, italic, and color.
+
+## 4. Elevation
+
+Flat by default; depth is a response to state, never a resting decoration. At rest, surfaces are matte and separated by hairline rules (`rule` / `rule-bright`), not by shadows. Atmosphere comes from two production sources: a fixed film-grain overlay (SVG fractal noise, ~3.5% opacity, `mix-blend-mode: overlay`) and two faint corner radial glows in Incident Ember/Warm Amber on the body — phosphor-bleed, not drop-shadow. Shadows appear only on interaction.
+
+### Shadow Vocabulary
+- **Hard Offset** (`box-shadow: 4px 4px 0 var(--color-rule-bright)`): The signature button hover. A crisp, mechanical offset — no blur — that pairs with a `translate(-2px,-2px)` lift. Reads as a physical key press, not a soft float.
+- **Ember Glow** (`box-shadow: 0 8px 24px -12px rgba(255,92,46,0.4)`): Hover lift on media posters. A diffuse ember halo that says "active" without lighting up at rest.
+- **Modal Lift** (`box-shadow: 0 30px 80px -20px rgba(0,0,0,0.7)`): Reserved for the search command palette — the one true overlay that must float above everything.
+
+### Named Rules
+**The Flat-At-Rest Rule.** Surfaces carry no shadow until the user touches them. Resting depth is hairline rules and tonal layering (`ink` → `ink-deep`). If a card has a drop-shadow sitting idle, it's wrong.
+
+**The Hard-Shadow Rule.** Interactive shadows are crisp offsets (`Xpx Ypx 0`), not soft ambient blur — the mechanical feel is intentional. Soft blur is allowed only for the ember glow and the single modal lift.
+
+## 5. Components
+
+Components feel **precise and mechanical** — sharp 1px rules, 2px radii, hard-offset hover shadows, mono labels. Well-built tooling, not soft product UI.
+
+### Buttons
+- **Shape:** Effectively square (2px radius — `rounded.sm`). Mono uppercase label, tracked, with a trailing `→` arrow.
+- **Primary (`.link-arrow-primary`):** Ember-filled at rest — `signal` background, `ink` text, `0.7rem 1rem` padding. The one filled-ember element marks the single action that matters (e.g. the hero's "View Talks"). Hover lifts `translate(-2px,-2px)` with a Hard Offset shadow in `ink-deep`. This filled CTA is *the action*; the ember on a status chip's border or an italic headline word is passive emphasis, so the One Signal Rule still holds.
+- **Secondary (`.link-arrow`):** Transparent fill, `paper` text, 1px `rule-bright` border, same padding. Hover fills with Incident Ember (text → `ink`), lifts with the Hard Offset shadow.
+- **Quiet (`.link-quiet`):** No box — `paper-dim` mono text + arrow, `0.7rem 0.4rem` padding for alignment/tap. Recedes behind the primary; hover shifts to `signal` and nudges the arrow. Used for tertiary hero links (Read Writing, Podcast).
+
+### Chips (`.mono-tag`)
+- **Style:** Transparent fill, mono `0.875rem` text, 1px `rule-bright` border, 2px radius, `0.35rem 0.7rem` padding, often led by a glyph (▲ ◆ ◉).
+- **State / Variants:** `chip-signal` (ember text + border) for emphasis; `chip-live` (live-green text + border) with a pulsing dot for upcoming/live status; `status-past` (dim text) for archived.
+
+### Cards / Containers (`.card`)
+- **Corner Style:** Square (0 radius). The crispness is the point.
+- **Background:** `ink` with a near-invisible top-down white gradient (1.2%→0) for the faintest sheen.
+- **Shadow Strategy:** None at rest (see Flat-At-Rest Rule); on hover the border brightens to `rule-bright` and the card lifts `translateY(-2px)`.
+- **Border:** 1px `rule`. A 2.5rem Incident Ember tick (`.card-accent`) pins the top-left corner.
+- **Internal Padding:** `2rem` (`spacing.lg`).
+
+### Inputs / Fields (search palette)
+- **Style:** The search input is borderless inside the panel, set in Instrument Serif *italic* `1.55rem` — the one place an input becomes display type. Caret is Incident Ember.
+- **Focus:** Global `:focus-visible` is a 2px Incident Ember outline, 3px offset. The palette itself rises with `search-rise` (0.18s) and sits on an ember-tinted blurred backdrop.
+
+### Navigation (`.nav-link`)
+- **Style:** Mono uppercase, `paper-dim` at rest. An Incident Ember underline grows from the left (`scaleX(0)→1`) on hover and on `[data-active="true"]`; text brightens to `paper`. Text labels, never icon-only (the search trigger carries an `aria-label` + `sr-only` text).
+
+### Talk Row (signature component)
+A three-column baseline-aligned grid (`7rem | 1fr | auto`): mono date, serif title + mono event, trailing arrow. On hover the whole row indents (`padding-left: 0.75rem`) and the title turns Incident Ember — a tactile "this is selectable" shift with no box or background. Collapses to a single column under 700px. This row is the workhorse of the talks and homepage listings and best captures the system's voice: mono metadata, serif object-title, ember on intent.
+
+## 6. Do's and Don'ts
+
+### Do:
+- **Do** keep the ground `ink` (#0c0c0a) or `ink-deep` (#050504). Warmth lives in the ember and the type, never in the background.
+- **Do** ration Incident Ember to ≤10% of a screen — the one action, link, or status that matters (The One Signal Rule).
+- **Do** set every piece of metadata (dates, sections, tags, kbd, status) in JetBrains Mono, uppercase, tracked 0.14em, at ≥0.875rem.
+- **Do** carry headline emphasis with Instrument Serif *italic* (and sparing ember), not bold.
+- **Do** keep surfaces flat at rest; let shadow be a response to hover/focus only (Hard Offset for buttons, Ember Glow for media).
+- **Do** use full 1px borders and hairline rules to separate content, with square-ish corners (0–2px).
+- **Do** keep the three text tiers legible: `paper` (~15.6:1) for primary, `paper-dim` (~5.2:1) for secondary, `paper-faint` (~4.8:1) for the quietest metadata — all clear AA. Differentiate them by size/case/tracking, not by dropping below contrast.
+- **Do** pair the grain overlay + corner radial glows for atmosphere instead of decorative gradients.
+- **Do** gate all motion behind `@media (prefers-reduced-motion: reduce)` — the rise reveals settle to their resting state and the live-dot stops pulsing when the preference is set.
+
+### Don't:
+- **Don't** ship the generic-SaaS landing page — no gradient blobs, rounded-card grids, hero-metric templates, or Inter-everywhere neutrality.
+- **Don't** drift into the corporate-LinkedIn résumé — no stock-photo professionalism, buzzword bullets, badge walls, or timeline widgets.
+- **Don't** scaffold like a trend-chasing AI template — no eyebrow kicker above every section, no identical icon-heading-text card rows. (Numbered section markers like § 01/02/03 count: drop them unless the section truly is an ordered sequence.)
+- **Don't** darken `paper-faint` back below ~4.5:1 on ink "for elegance" — the quiet tier must stay legible. Carry "even quieter" decoration with opacity on a passing color, not an out-of-contrast token.
+- **Don't** use a colored `border-left`/`border-right` stripe wider than 1px as an accent; use a full border or a corner tick (`.card-accent`) instead.
+- **Don't** use `background-clip: text` gradient headlines or decorative glassmorphism.
+- **Don't** let two elements be ember at once in the same view — it kills the signal.
+- **Don't** soften the system toward beige, rounded, or shadowed-at-rest; if it looks cozy, it's off-brand.

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -1,0 +1,78 @@
+# Product
+
+## Register
+
+brand
+
+## Users
+
+Engineering peers and conference/community organisers who land here from a talk,
+the YBYR podcast, the Prague Go Meetup, GitHub, or a search for Ladislav's
+writing. They arrive curious about *who this person is and whether they're worth
+listening to* — fellow SREs and backend engineers, conference program
+committees scouting speakers, podcast hosts, and meetup attendees. They're
+technical, skim fast, and trust signal over polish. The job: in under a minute,
+decide "yes, this person knows production and is worth my time" — then find the
+talk, post, or contact link they came for.
+
+## Product Purpose
+
+A personal reputation surface for Ladislav Prskavec — Software Engineer & SRE in
+Prague. It exists to establish credibility and convert it into invitations:
+conference talks, podcast appearances, meetup attendance, and direct contact.
+Writing, the OnCall design guide, talks archive, the You Build It You Run It
+podcast, and the Prague Go Meetup are the proof points. Success is a visitor
+leaving with a clear sense of expertise (on-call hygiene, observability, Go,
+distributed systems) and a low-friction path to the thing they want — not
+pageviews, but the right reach-outs.
+
+## Brand Personality
+
+Bold, technical, precise. Confident without bravado — the voice of an engineer
+who has run real production systems and has opinions earned at 3am. High
+contrast over comfort: the dark editorial surface, the signal-orange accent, and
+the mono labels are intentional terminal-native edge, not decoration. Tone is
+direct and unhyped: short declaratives, no marketing gloss, dry wit allowed.
+The site should feel *built by someone who builds*, where craft is the argument.
+
+## Anti-references
+
+- **Generic SaaS / startup landing pages.** No gradient blobs, rounded-card
+  grids, hero-metric templates, "trusted by" logo walls, or Inter-everywhere
+  neutrality. Safe and templated reads as having nothing to say.
+- **Corporate LinkedIn résumé.** No stock-photo professionalism, buzzword
+  bullets, badge walls, or timeline widgets. Credibility comes from the work
+  shown, not from claims of seniority.
+- **Trend-chasing AI-template.** No eyebrow kicker above every section, no
+  identical icon-heading-text card rows, no scaffolding that signals "a machine
+  filled in the blanks." A visitor should wonder how it was made, not which tool
+  made it.
+
+Note: the site currently lives in the editorial-typographic lane (display serif
++ mono labels + ruled separators). That's a committed identity, not a fresh
+reflex — preserve it. New work refines this voice; it does not restart it.
+
+## Design Principles
+
+1. **Show the work, don't claim it.** Talks, posts, and the OnCall guide are the
+   credibility — surface them; never assert expertise the content doesn't back.
+2. **Signal over polish.** Every element should earn its place. Density and
+   restraint beat decoration; if it doesn't carry meaning, cut it.
+3. **Built by someone who builds.** Craft *is* the argument — typography,
+   spacing, and motion should feel deliberate enough to be their own proof of
+   competence.
+4. **Commit to the contrast.** The dark/signal-orange/mono identity is the
+   voice. Lean into it; don't hedge toward neutral safety.
+5. **Respect the skimmer.** Technical readers scan and leave fast — make the
+   "who/what/why" and the path to talks, writing, and contact obvious in
+   seconds.
+
+## Accessibility & Inclusion
+
+Best-effort, no formal WCAG target committed. Practical bar to hold anyway:
+body and label text must stay comfortably legible against the dark ground
+(paper `#ede4d3` on ink `#0c0c0a` clears AA; watch dimmer `paper-dim` /
+`paper-faint` tones on small text and bump toward paper when contrast is close).
+Honour `prefers-reduced-motion` for the rise/pulse animations, keep keyboard
+focus visible (the signal-orange `:focus-visible` ring), and don't rely on the
+signal-orange accent alone to convey state.

--- a/assets/css/input.css
+++ b/assets/css/input.css
@@ -1,4 +1,3 @@
-@import url("https://fonts.googleapis.com/css2?family=Instrument+Serif:ital@0;1&family=JetBrains+Mono:ital,wght@0,400;0,500;0,700;1,400&family=Newsreader:ital,opsz,wght@0,6..72,300;0,6..72,400;0,6..72,500;0,6..72,600;0,6..72,700;1,6..72,400&display=swap");
 @import "tailwindcss";
 
 @source "../../layouts/**/*.html";
@@ -9,7 +8,7 @@
   --color-ink-deep: #050504;
   --color-paper: #ede4d3;
   --color-paper-dim: #8b8378;
-  --color-paper-faint: #4a4640;
+  --color-paper-faint: #857c6e;
   --color-rule: #2a2823;
   --color-rule-bright: #3a382f;
   --color-signal: #ff5c2e;
@@ -19,9 +18,6 @@
   --font-display: "Instrument Serif", "Iowan Old Style", "Georgia", serif;
   --font-body: "Newsreader", "Iowan Old Style", "Georgia", serif;
   --font-mono: "JetBrains Mono", ui-monospace, "SF Mono", monospace;
-
-  --text-mega: clamp(4rem, 14vw, 12rem);
-  --text-huge: clamp(2.5rem, 7vw, 6rem);
 
   --tracking-label: 0.14em;
   --tracking-tight-label: 0.05em;
@@ -39,8 +35,8 @@
 
   body {
     background:
-      radial-gradient(1200px circle at 80% -10%, rgba(255, 92, 46, 0.08), transparent 55%),
-      radial-gradient(900px circle at -5% 110%, rgba(255, 174, 58, 0.04), transparent 55%),
+      radial-gradient(1200px circle at 80% -10%, color-mix(in srgb, var(--color-signal) 8%, transparent), transparent 55%),
+      radial-gradient(900px circle at -5% 110%, color-mix(in srgb, var(--color-signal-warm) 4%, transparent), transparent 55%),
       var(--color-ink);
     min-height: 100vh;
     position: relative;
@@ -295,9 +291,11 @@
 }
 
 .prose-editorial pre {
-  background: var(--color-ink-deep);
+  /* Ember corner tick drawn as a fixed gradient so it doesn't scroll with code. */
+  background:
+    linear-gradient(var(--color-signal), var(--color-signal)) top left / 2.5rem 2px no-repeat,
+    var(--color-ink-deep);
   border: 1px solid var(--color-rule);
-  border-left: 2px solid var(--color-signal);
   padding: 1.5rem 1.75rem;
   border-radius: 4px;
   overflow-x: auto;
@@ -321,7 +319,6 @@
   margin: 2rem 0;
   border-radius: 4px;
   border: 1px solid var(--color-rule);
-  border-left: 2px solid var(--color-signal);
   overflow: hidden;
 }
 
@@ -397,7 +394,7 @@
 }
 
 .prose-editorial tbody tr:hover {
-  background: rgba(255, 92, 46, 0.04);
+  background: color-mix(in srgb, var(--color-signal) 4%, transparent);
 }
 
 .prose-editorial tbody tr:hover td {
@@ -435,7 +432,6 @@
 .prose-editorial .reader-video {
   margin: 2.5rem 0;
   border: 1px solid var(--color-rule);
-  border-left: 2px solid var(--color-signal);
   border-radius: 4px;
   overflow: hidden;
   background: var(--color-ink-deep);
@@ -480,6 +476,43 @@
   transform: translateX(3px);
 }
 
+/* Primary CTA: ember-filled at rest — the one action that matters. */
+.link-arrow-primary {
+  background: var(--color-signal);
+  color: var(--color-ink);
+  border-color: var(--color-signal);
+}
+
+.link-arrow-primary:hover {
+  box-shadow: 4px 4px 0 var(--color-ink-deep);
+}
+
+/* Quiet secondary link: no box, recedes behind the primary. */
+.link-quiet {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  color: var(--color-paper-dim);
+  font-family: var(--font-mono);
+  font-size: 1rem;
+  letter-spacing: var(--tracking-tight-label);
+  text-transform: uppercase;
+  padding: 0.7rem 0.4rem;
+  transition: color 0.18s ease;
+}
+
+.link-quiet:hover {
+  color: var(--color-signal);
+}
+
+.link-quiet .arr {
+  transition: transform 0.18s ease;
+}
+
+.link-quiet:hover .arr {
+  transform: translateX(3px);
+}
+
 /* ── Section header (mono label + rule line) ─────────────────────────── */
 .section-marker {
   display: flex;
@@ -503,7 +536,7 @@
   padding: 1.5rem 0;
   border-top: 1px solid var(--color-rule);
   align-items: baseline;
-  transition: padding 0.2s ease;
+  transition: transform 0.2s ease;
 }
 
 .talk-row:last-child {
@@ -511,7 +544,7 @@
 }
 
 .talk-row:hover {
-  padding-left: 0.75rem;
+  transform: translateX(0.75rem);
 }
 
 .talk-row:hover .talk-title {
@@ -660,7 +693,6 @@
   aspect-ratio: 16 / 9;
   background: var(--color-ink-deep);
   border: 1px solid var(--color-rule);
-  border-left: 2px solid var(--color-signal);
   border-radius: 4px;
   overflow: hidden;
   cursor: pointer;
@@ -676,7 +708,7 @@
 .media-poster:hover {
   border-color: var(--color-signal);
   transform: translateY(-2px);
-  box-shadow: 0 8px 24px -12px rgba(255, 92, 46, 0.4);
+  box-shadow: 0 8px 24px -12px color-mix(in srgb, var(--color-signal) 40%, transparent);
 }
 
 .media-thumb {
@@ -714,7 +746,7 @@
 
 .media-poster-slides .media-overlay {
   background:
-    radial-gradient(ellipse at top right, rgba(255, 92, 46, 0.12), transparent 55%),
+    radial-gradient(ellipse at top right, color-mix(in srgb, var(--color-signal) 12%, transparent), transparent 55%),
     linear-gradient(135deg, rgba(12, 12, 10, 0.6), rgba(5, 5, 4, 0.95));
 }
 
@@ -739,7 +771,7 @@
 /* Reader (annotated presentation): horizontal page-rule texture */
 .media-poster-reader .media-overlay {
   background:
-    radial-gradient(ellipse at bottom left, rgba(184, 255, 92, 0.10), transparent 55%),
+    radial-gradient(ellipse at bottom left, color-mix(in srgb, var(--color-live) 10%, transparent), transparent 55%),
     linear-gradient(135deg, rgba(12, 12, 10, 0.6), rgba(5, 5, 4, 0.94));
 }
 
@@ -778,7 +810,7 @@
   place-items: center;
   border: 1px solid var(--color-rule-bright);
   border-radius: 999px;
-  background: rgba(255, 92, 46, 0.15);
+  background: color-mix(in srgb, var(--color-signal) 15%, transparent);
   color: var(--color-signal);
   font-family: var(--font-mono);
   font-size: 1.1rem;
@@ -799,7 +831,6 @@
   width: 100%;
   aspect-ratio: 16 / 9;
   border: 1px solid var(--color-rule-bright);
-  border-left: 2px solid var(--color-signal);
   border-radius: 4px;
   overflow: hidden;
   background: var(--color-ink-deep);
@@ -815,7 +846,7 @@
 
 /* ── Talk photos (audience / venue gallery) ─────────────────────── */
 .talk-photo {
-  border-left: 2px solid var(--color-signal);
+  border: 1px solid var(--color-rule);
   border-radius: 4px;
   cursor: zoom-in;
   background: var(--color-ink-deep);
@@ -852,7 +883,6 @@
   max-width: 100%;
   max-height: 100%;
   border: 1px solid var(--color-rule-bright);
-  border-left: 2px solid var(--color-signal);
   border-radius: 4px;
 }
 
@@ -889,7 +919,7 @@
   color: var(--color-paper-dim);
   background: transparent;
   border: 1px solid var(--color-rule);
-  border-radius: 3px;
+  border-radius: 2px;
   cursor: pointer;
   transition: color 0.15s ease, border-color 0.15s ease;
 }
@@ -942,7 +972,7 @@
   position: absolute;
   inset: 0;
   background:
-    radial-gradient(1200px circle at 50% 0%, rgba(255, 92, 46, 0.06), transparent 60%),
+    radial-gradient(1200px circle at 50% 0%, color-mix(in srgb, var(--color-signal) 6%, transparent), transparent 60%),
     rgba(5, 5, 4, 0.85);
   backdrop-filter: blur(6px);
   -webkit-backdrop-filter: blur(6px);
@@ -954,7 +984,6 @@
   max-width: 640px;
   background: var(--color-ink);
   border: 1px solid var(--color-rule-bright);
-  border-left: 2px solid var(--color-signal);
   border-radius: 6px;
   box-shadow: 0 30px 80px -20px rgba(0, 0, 0, 0.7);
   max-height: 80vh;
@@ -1043,7 +1072,7 @@
 .search-results li:last-child .search-hit { border-bottom: 0; }
 
 .search-hit[aria-selected="true"] {
-  background: rgba(255, 92, 46, 0.07);
+  background: color-mix(in srgb, var(--color-signal) 7%, transparent);
 }
 
 .search-hit[aria-selected="true"] .search-hit-title {
@@ -1097,7 +1126,7 @@
 }
 
 .search-hit mark {
-  background: rgba(255, 92, 46, 0.22);
+  background: color-mix(in srgb, var(--color-signal) 22%, transparent);
   color: var(--color-signal-warm);
   padding: 0 0.05em;
   border-radius: 1px;
@@ -1160,4 +1189,96 @@
   outline: 2px solid var(--color-signal);
   outline-offset: 3px;
   border-radius: 1px;
+}
+
+/* ── Reduced motion ───────────────────────────────────────────────────── */
+/* Honour the OS preference: kill movement everywhere, settle reveals to their
+   visible resting state, and stop the looping pulse. Content never depends on
+   a transition firing, so near-instant durations are safe. */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+
+  /* Reveals show at rest (no translate); the live dot holds steady. */
+  .rise { animation: none; }
+  .live-dot { animation: none; }
+}
+
+/* ── Ember corner tick ────────────────────────────────────────────────── */
+/* Replaces the former 2px left-stripe accent on code, media, and the search
+   panel: a short ember bar pinned to the top-left corner, the same signature
+   as .card-accent. Code blocks (.prose-editorial pre) draw it as a fixed
+   background gradient instead, so it survives horizontal scroll. */
+.prose-editorial .highlight,
+.prose-editorial .reader-video,
+.media-poster,
+.media-frame,
+.search-panel {
+  position: relative;
+}
+
+.prose-editorial .highlight::before,
+.prose-editorial .reader-video::before,
+.media-poster::before,
+.media-frame::before,
+.search-panel::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 2.5rem;
+  height: 2px;
+  background: var(--color-signal);
+  z-index: 3;
+  pointer-events: none;
+}
+
+/* ── Touch tap targets ────────────────────────────────────────────────── */
+/* On touch (coarse) pointers, grow nav links to a comfortable ~40px target.
+   inline-block makes padding-block lay out for both the flex header nav and
+   the inline footer list; the underline is nudged to keep its 4px gap. */
+@media (pointer: coarse) {
+  .nav-link {
+    display: inline-block;
+    padding-block: 0.5rem;
+  }
+  .nav-link::after {
+    bottom: 0.25rem;
+  }
+}
+
+/* ── Skip to content ──────────────────────────────────────────────────── */
+/* Off-screen until the first Tab focuses it; sits above the search overlay. */
+.skip-link {
+  position: absolute;
+  left: 0.5rem;
+  top: -4rem;
+  z-index: 200;
+  padding: 0.6rem 1rem;
+  font-family: var(--font-mono);
+  font-size: 0.875rem;
+  letter-spacing: var(--tracking-tight-label);
+  text-transform: uppercase;
+  color: var(--color-paper);
+  background: var(--color-ink-deep);
+  border: 1px solid var(--color-signal);
+  border-radius: 2px;
+  transition: top 0.18s ease;
+}
+
+.skip-link:focus {
+  top: 0.5rem;
+  outline: 2px solid var(--color-signal);
+  outline-offset: 2px;
+}
+
+/* Focus moves here via the skip link; no ring needed on the region itself. */
+#main:focus {
+  outline: none;
 }

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -4,9 +4,10 @@
     {{ partial "head.html" . }}
   </head>
   <body class="antialiased">
+    <a href="#main" class="skip-link">Skip to content</a>
     <div class="grain" aria-hidden="true"></div>
     {{ partial "header.html" . }}
-    <main id="main">
+    <main id="main" tabindex="-1">
       {{ block "main" . }}{{ end }}
     </main>
     {{ partial "footer.html" . }}

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -17,7 +17,7 @@
         <span class="mono-tag mono-tag-signal">▲ Based in Prague · CET</span>
       </div>
 
-      <h1 class="display text-[clamp(2.8rem,9vw,8.5rem)] leading-[0.98] rise rise-2">
+      <h1 class="display text-[clamp(2.8rem,8vw,6rem)] leading-[0.98] rise rise-2">
         Software <em class="italic text-[color:var(--color-signal)]">reliability</em>,
         <br>
         distributed <em class="italic">systems</em>,
@@ -34,9 +34,9 @@
       </p>
 
       <div class="mt-10 flex flex-wrap gap-3 rise rise-4">
-        <a href="/talk/" class="link-arrow">View Talks <span class="arr">→</span></a>
-        <a href="/post/" class="link-arrow">Read Writing <span class="arr">→</span></a>
-        <a href="https://ybyr.net/podcast" target="_blank" rel="noopener" class="link-arrow">Podcast: YBYR ↗</a>
+        <a href="/talk/" class="link-arrow link-arrow-primary">View Talks <span class="arr">→</span></a>
+        <a href="/post/" class="link-quiet">Read Writing <span class="arr">→</span></a>
+        <a href="https://ybyr.net/podcast" target="_blank" rel="noopener" class="link-quiet">Podcast: YBYR ↗</a>
       </div>
     </div>
 
@@ -71,7 +71,7 @@
           </dd>
         </dl>
 
-        <div class="mt-6 pt-5 border-t border-[color:var(--color-rule)] font-[family-name:var(--font-mono)] text-xs tracking-[0.14em] uppercase text-[color:var(--color-paper-faint)] leading-relaxed">
+        <div class="mt-6 pt-5 border-t border-[color:var(--color-rule)] font-[family-name:var(--font-mono)] text-sm tracking-[0.14em] uppercase text-[color:var(--color-paper-faint)] leading-relaxed">
           Talks delivered: {{ len $pastTalks }} · Posts published: {{ len (where site.RegularPages "Section" "post") }}
         </div>
       </div>
@@ -110,7 +110,7 @@
 {{ if $recentTalks }}
 <section class="relative z-10 px-6 md:px-12 lg:px-20 mb-32">
   <div class="section-marker">
-    <span class="mono-label">§ 01 / Recent Talks</span>
+    <h2 class="mono-label">§ Recent Talks</h2>
     <a href="/talk/" class="mono-label hover:text-[color:var(--color-signal)] transition-colors">All {{ len $allTalks }} →</a>
   </div>
   <ul>
@@ -133,7 +133,7 @@
 {{/* ── PODCAST + MEETUP DUET ──────────────────────────────────────────── */}}
 <section class="relative z-10 px-6 md:px-12 lg:px-20 mb-32">
   <div class="section-marker">
-    <span class="mono-label">§ 02 / Communities</span>
+    <h2 class="mono-label">§ Communities</h2>
   </div>
 
   <div class="grid gap-6 md:grid-cols-2">
@@ -142,7 +142,7 @@
       <span class="card-accent"></span>
       <div class="flex items-baseline justify-between mb-6">
         <span class="mono-tag mono-tag-signal">◉ Podcast</span>
-        <span class="font-[family-name:var(--font-mono)] text-xs text-[color:var(--color-paper-faint)] group-hover:text-[color:var(--color-signal)] transition-colors">ybyr.net ↗</span>
+        <span class="font-[family-name:var(--font-mono)] text-sm text-[color:var(--color-paper-faint)] group-hover:text-[color:var(--color-signal)] transition-colors">ybyr.net ↗</span>
       </div>
       <h3 class="display italic text-4xl md:text-5xl leading-[0.95] mb-4 group-hover:text-[color:var(--color-signal)] transition-colors">
         You Build It,<br>You Run It.
@@ -161,7 +161,7 @@
       <span class="card-accent"></span>
       <div class="flex items-baseline justify-between mb-6">
         <span class="mono-tag mono-tag-signal">▲ Meetup</span>
-        <span class="font-[family-name:var(--font-mono)] text-xs text-[color:var(--color-paper-faint)] group-hover:text-[color:var(--color-signal)] transition-colors">gomeetupprague.cz ↗</span>
+        <span class="font-[family-name:var(--font-mono)] text-sm text-[color:var(--color-paper-faint)] group-hover:text-[color:var(--color-signal)] transition-colors">gomeetupprague.cz ↗</span>
       </div>
       <h3 class="display italic text-4xl md:text-5xl leading-[0.95] mb-4 group-hover:text-[color:var(--color-signal)] transition-colors">
         Prague Go<br>Meetup.
@@ -181,7 +181,7 @@
 {{ if $recentPosts }}
 <section class="relative z-10 px-6 md:px-12 lg:px-20 mb-24">
   <div class="section-marker">
-    <span class="mono-label">§ 03 / Recent Writing</span>
+    <h2 class="mono-label">§ Recent Writing</h2>
     <a href="/post/" class="mono-label hover:text-[color:var(--color-signal)] transition-colors">All posts →</a>
   </div>
 

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -54,6 +54,7 @@
 {{/* ── Fonts + stylesheet ──────────────────────────────────────── */}}
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Instrument+Serif:ital@0;1&family=JetBrains+Mono:ital,wght@0,400;0,500;0,700;1,400&family=Newsreader:ital,opsz,wght@0,6..72,300;0,6..72,400;0,6..72,500;0,6..72,600;0,6..72,700;1,6..72,400&display=swap">
 
 <link rel="stylesheet" href="{{ "/css/output.css" | relURL }}">
 

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -7,7 +7,7 @@
       <a href="{{ "/" | relURL }}" class="mono-label hover:text-[color:var(--color-paper)] transition-colors">/ prskavec.net</a>
     </div>
 
-    <nav aria-label="Primary" class="flex items-center gap-5 md:gap-7">
+    <nav aria-label="Primary" class="flex flex-wrap items-center gap-x-5 gap-y-1 md:gap-x-7">
       {{ $cur := .RelPermalink }}
       <a class="nav-link" data-active="{{ eq $cur "/" }}" href="{{ "/" | relURL }}">Index</a>
       <a class="nav-link" data-active="{{ hasPrefix $cur "/talk" }}" href="{{ "/talk/" | relURL }}">Talks</a>


### PR DESCRIPTION
## What

Sets up design-system docs for the site and runs a full accessibility / responsive / polish pass over the homepage, driven by an `impeccable` critique + audit.

New project docs:
- **`PRODUCT.md`** — brand register, audience, the "credibility & speaking" purpose, bold/technical personality, anti-references, principles.
- **`DESIGN.md`** — the visual system as tokens + prose ("The 3AM Console": near-black ground, one incident-orange signal, Instrument Serif / Newsreader / JetBrains Mono).

## Changes

**Accessibility**
- Faint-text contrast: `--color-paper-faint` `#4a4640` → `#857c6e` (~2.1:1 → ~4.8:1, clears AA) — fixes vitals stats, colophon, breadcrumbs site-wide.
- `prefers-reduced-motion` fallback for the rise / live-pulse / search animations.
- Section markers `<span>` → real `<h2>`s; added a skip-to-content link + focusable `<main>`.
- ~40px tap targets on `pointer: coarse`; nav wraps instead of overflowing on narrow screens.

**De-slop / identity**
- Removed `01 / 02 / 03` section numbering (kept named markers).
- Replaced the 2px ember `border-left` side-stripe on 8 components with the corner-tick motif.

**Performance**
- Fonts off the CSS `@import` chain → parallel `<link>` in `<head>`.
- `talk-row` hover: `padding` → `transform` (composited, no reflow).

**Typography & hierarchy**
- Hero clamp capped at the 6rem ceiling (`clamp(2.8rem, 8vw, 6rem)`).
- Sub-floor mono labels raised to ≥0.875rem.
- Ember-filled primary hero CTA (View Talks) with quiet secondaries.

**Token hygiene**
- Accent `rgba()` literals → `color-mix(in srgb, var(--color-…) N%, transparent)`.
- Removed dead `--text-mega` / `--text-huge` tokens.

## Notes

- `.gitignore` now excludes `.impeccable/` (local skill state). `static/css/output.css` stays ignored — Netlify rebuilds it from `assets/css/input.css`.
- Verified via the bundled detector + local Tailwind/Hugo builds; **not** click-tested in a live browser — worth an eyeball at 360px / 1440px before merge.
- Playwright smoke/search suite runs against production, so it validates post-deploy.
