### PR TITLE
[codex] restore RSS feed discovery

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -15,6 +15,7 @@
         <li><a class="nav-link" href="https://twitter.com/abtris" target="_blank" rel="noopener">twitter.com/abtris ↗</a></li>
         <li><a class="nav-link" href="https://ybyr.net/podcast" target="_blank" rel="noopener">ybyr.net (podcast) ↗</a></li>
         <li><a class="nav-link" href="https://www.gomeetupprague.cz/" target="_blank" rel="noopener">gomeetupprague.cz ↗</a></li>
+        <li><a class="nav-link" href="{{ "/index.xml" | relURL }}">RSS feed</a></li>
       </ul>
     </div>
 

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -45,6 +45,9 @@
 <link rel="icon" type="image/svg+xml" href="{{ "/favicon.svg" | relURL }}">
 <link rel="icon" type="image/x-icon" href="{{ "/favicon.ico" | relURL }}">
 <link rel="apple-touch-icon" sizes="180x180" href="{{ "/apple-touch-icon.png" | relURL }}">
+{{ with .OutputFormats.Get "RSS" }}
+<link rel="alternate" type="{{ .MediaType }}" href="{{ .Permalink }}" title="{{ if $.IsHome }}{{ site.Title }}{{ else }}{{ $.Title }} — {{ site.Title }}{{ end }}">
+{{ end }}
 
 {{/* ── Fonts + stylesheet ──────────────────────────────────────── */}}
 <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/tests/smoke.spec.ts
+++ b/tests/smoke.spec.ts
@@ -34,6 +34,12 @@ test.describe('Homepage', () => {
     await expect(page.getByRole('link', { name: /ladislav@prskavec\.net/i }).first()).toBeVisible();
   });
 
+  test('RSS feed is discoverable', async ({ page }) => {
+    await page.goto('/');
+    await expect(page.locator('link[rel="alternate"][type="application/rss+xml"]')).toHaveAttribute('href', /\/index\.xml$/);
+    await expect(page.getByRole('link', { name: 'RSS feed' })).toHaveAttribute('href', '/index.xml');
+  });
+
   test('no placeholder subtitle copy is visible', async ({ page }) => {
     await page.goto('/');
     await expect(page.getByText('MY FANS')).toHaveCount(0);


### PR DESCRIPTION
## What changed

- Restore RSS autodiscovery links in the shared HTML head using Hugo's existing RSS output format.
- Add a visible footer link to the site RSS feed at /index.xml.
- Add a smoke test that checks both the alternate feed link and visible RSS link.

## Why

The new design still generated RSS XML, but dropped discoverability from the rendered HTML. Feed readers and users no longer had an obvious way to find the feeds.

## Validation

- hugo --destination /tmp/prskavec-rss-check
- npx playwright test tests/smoke.spec.ts