### PR TITLE
[codex] expand RSS links and fix search overlay tests

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -15,9 +15,6 @@
         <li><a class="nav-link" href="https://twitter.com/abtris" target="_blank" rel="noopener">twitter.com/abtris ↗</a></li>
         <li><a class="nav-link" href="https://ybyr.net/podcast" target="_blank" rel="noopener">ybyr.net (podcast) ↗</a></li>
         <li><a class="nav-link" href="https://www.gomeetupprague.cz/" target="_blank" rel="noopener">gomeetupprague.cz ↗</a></li>
-        <li><a class="nav-link" href="{{ "/index.xml" | relURL }}">All RSS</a></li>
-        <li><a class="nav-link" href="{{ "/post/index.xml" | relURL }}">Posts RSS</a></li>
-        <li><a class="nav-link" href="{{ "/talk/index.xml" | relURL }}">Talks RSS</a></li>
       </ul>
     </div>
 
@@ -26,6 +23,11 @@
       <a href="mailto:ladislav@prskavec.net" class="display italic text-2xl text-[color:var(--color-paper)] hover:text-[color:var(--color-signal)] transition-colors">
         ladislav@prskavec.net
       </a>
+      <ul class="mt-5 space-y-1.5 font-[family-name:var(--font-mono)] text-sm">
+        <li><a class="nav-link" href="{{ "/index.xml" | relURL }}">All RSS</a></li>
+        <li><a class="nav-link" href="{{ "/post/index.xml" | relURL }}">Posts RSS</a></li>
+        <li><a class="nav-link" href="{{ "/talk/index.xml" | relURL }}">Talks RSS</a></li>
+      </ul>
       <div class="mono-label mt-6 text-[color:var(--color-paper-faint)]">
         © {{ now.Format "2006" }} — Built with Hugo · Set in Instrument Serif, Newsreader & JetBrains Mono
       </div>

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -15,7 +15,9 @@
         <li><a class="nav-link" href="https://twitter.com/abtris" target="_blank" rel="noopener">twitter.com/abtris ↗</a></li>
         <li><a class="nav-link" href="https://ybyr.net/podcast" target="_blank" rel="noopener">ybyr.net (podcast) ↗</a></li>
         <li><a class="nav-link" href="https://www.gomeetupprague.cz/" target="_blank" rel="noopener">gomeetupprague.cz ↗</a></li>
-        <li><a class="nav-link" href="{{ "/index.xml" | relURL }}">RSS feed</a></li>
+        <li><a class="nav-link" href="{{ "/index.xml" | relURL }}">All RSS</a></li>
+        <li><a class="nav-link" href="{{ "/post/index.xml" | relURL }}">Posts RSS</a></li>
+        <li><a class="nav-link" href="{{ "/talk/index.xml" | relURL }}">Talks RSS</a></li>
       </ul>
     </div>
 

--- a/static/js/search.js
+++ b/static/js/search.js
@@ -201,10 +201,16 @@
 
   overlay.addEventListener('click', (e) => {
     // Click on the backdrop (not the inner panel) closes
-    if (e.target === overlay || e.target.dataset.searchClose) close();
+    if (e.target === overlay || e.target.hasAttribute('data-search-close')) close();
   });
 
   document.addEventListener('keydown', (e) => {
+    if (e.key === 'Escape' && overlay.dataset.open === 'true') {
+      e.preventDefault();
+      close();
+      return;
+    }
+
     // "/" opens the overlay (GitHub-style); skipped when the user is typing
     // in any form field so they can still type a literal slash there.
     if (e.key === '/' && overlay.dataset.open !== 'true') {

--- a/tests/search.spec.ts
+++ b/tests/search.spec.ts
@@ -68,7 +68,7 @@ test.describe('Search overlay', () => {
     expect(href).toMatch(/^\/|prskavec\.net/);
 
     await firstHit.click();
-    await expect(page).not.toHaveURL(/\/$|^http:\/\/localhost:1313\/$/);
+    await expect(page).not.toHaveURL('/');
   });
 
   test('a query with no matches shows the empty state', async ({ page }) => {
@@ -94,7 +94,7 @@ test.describe('Search overlay', () => {
     const overlay = page.locator('#search-overlay');
     await expect(overlay).toHaveAttribute('data-open', 'true');
 
-    await page.locator('.search-backdrop').click();
+    await page.locator('.search-backdrop').click({ position: { x: 10, y: 10 } });
     await expect(overlay).toHaveAttribute('data-open', 'false');
   });
 

--- a/tests/smoke.spec.ts
+++ b/tests/smoke.spec.ts
@@ -37,7 +37,9 @@ test.describe('Homepage', () => {
   test('RSS feed is discoverable', async ({ page }) => {
     await page.goto('/');
     await expect(page.locator('link[rel="alternate"][type="application/rss+xml"]')).toHaveAttribute('href', /\/index\.xml$/);
-    await expect(page.getByRole('link', { name: 'RSS feed' })).toHaveAttribute('href', '/index.xml');
+    await expect(page.getByRole('link', { name: 'All RSS' })).toHaveAttribute('href', '/index.xml');
+    await expect(page.getByRole('link', { name: 'Posts RSS' })).toHaveAttribute('href', '/post/index.xml');
+    await expect(page.getByRole('link', { name: 'Talks RSS' })).toHaveAttribute('href', '/talk/index.xml');
   });
 
   test('no placeholder subtitle copy is visible', async ({ page }) => {


### PR DESCRIPTION
## What changed

- Replace the single footer RSS link with three feeds: all content, posts, and talks.
- Move RSS links from the Elsewhere column into the Contact column.
- Fix search overlay close behavior for data-search-close elements and document-level Escape.
- Tighten Playwright search assertions so valid trailing-slash URLs do not fail.

## Why

The site now exposes the expected RSS feed choices in a more appropriate footer location. The linked Actions run also showed existing Playwright failures in the search overlay tests, caused by brittle assertions and a real close-handler bug for empty data-search-close attributes.

## Validation

- npx playwright test