### PR TITLE
Reach quick wins: GA4 tag, full-text RSS, OnCall guide promo, LinkedIn link

### DIFF
--- a/config/_default/config.toml
+++ b/config/_default/config.toml
@@ -34,6 +34,12 @@ ignoreLogs = ['warning-goldmark-raw-html']
   home = [ "HTML", "RSS", "JSON", "LLMS" ]
   section = [ "HTML", "RSS" ]
 
+# Google Analytics 4 — emitted by the internal template in head.html,
+# production builds only (HUGO_ENV=production, set in netlify.toml).
+[services]
+  [services.googleAnalytics]
+    ID = "G-YGZB4EL45B"
+
 # Custom output format for /llms.txt — see https://llmstxt.org
 [outputFormats]
   [outputFormats.LLMS]

--- a/layouts/_default/rss.xml
+++ b/layouts/_default/rss.xml
@@ -4,7 +4,7 @@
   {{- $pages = $pages | first $limit -}}
 {{- end -}}
 {{- printf "<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"yes\" ?>" | safeHTML }}
-<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom" xmlns:content="http://purl.org/rss/1.0/modules/content/">
   <channel>
     <title>{{ if eq .Title site.Title }}{{ site.Title }}{{ else }}{{ with .Title }}{{ . }} on {{ end }}{{ site.Title }}{{ end }}</title>
     <link>{{ .Permalink }}</link>
@@ -36,6 +36,7 @@
       {{- end }}
       <guid>{{ .Permalink }}</guid>
       <description>{{ with .Params.summary }}{{ . | html }}{{ else }}{{ .Summary | html }}{{ end }}</description>
+      <content:encoded>{{ .Content | html }}</content:encoded>
     </item>
     {{- end }}
   </channel>

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -130,6 +130,31 @@
 </section>
 {{ end }}
 
+{{/* ── ONCALL GUIDE ───────────────────────────────────────────────────── */}}
+{{ with site.GetPage "/courses/how-to-make-oncall" }}
+<section class="relative z-10 px-6 md:px-12 lg:px-20 mb-32">
+  <div class="border-y border-[color:var(--color-rule)] py-10 md:py-14 grid gap-8 md:grid-cols-[1fr_auto] items-center rise">
+    <div class="min-w-0">
+      <div class="flex items-center gap-4 mb-5">
+        <span class="mono-tag mono-tag-signal">▣ Field Guide</span>
+        <span class="mono-label">{{ len .Pages }} chapters · free to read</span>
+      </div>
+      <a href="{{ .RelPermalink }}" class="block group">
+        <h2 class="display italic text-3xl md:text-5xl lg:text-6xl leading-[0.95] group-hover:text-[color:var(--color-signal)] transition-colors">
+          On-call that doesn't kill your team.
+        </h2>
+        <p class="mt-5 max-w-[68ch] text-lg leading-snug text-[color:var(--color-paper-dim)]">
+          A practical guide to designing on-call from scratch — rosters and schedules,
+          alert budgets, escalation policies, documentation, postmortems, and the
+          tooling market. Opinions earned running real 24/7 rotations.
+        </p>
+      </a>
+    </div>
+    <a href="{{ .RelPermalink }}" class="link-arrow whitespace-nowrap">Read the Guide <span class="arr">→</span></a>
+  </div>
+</section>
+{{ end }}
+
 {{/* ── PODCAST + MEETUP DUET ──────────────────────────────────────────── */}}
 <section class="relative z-10 px-6 md:px-12 lg:px-20 mb-32">
   <div class="section-marker">

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -13,6 +13,7 @@
         <li><a class="nav-link" href="https://github.com/abtris" target="_blank" rel="noopener">github.com/abtris ↗</a></li>
         <li><a class="nav-link" href="https://hachyderm.io/@abtris" target="_blank" rel="noopener">hachyderm.io/@abtris ↗</a></li>
         <li><a class="nav-link" href="https://twitter.com/abtris" target="_blank" rel="noopener">twitter.com/abtris ↗</a></li>
+        <li><a class="nav-link" href="https://www.linkedin.com/in/ladislavprskavec/" target="_blank" rel="noopener">linkedin.com/in/ladislavprskavec ↗</a></li>
         <li><a class="nav-link" href="https://ybyr.net/podcast" target="_blank" rel="noopener">ybyr.net (podcast) ↗</a></li>
         <li><a class="nav-link" href="https://www.gomeetupprague.cz/" target="_blank" rel="noopener">gomeetupprague.cz ↗</a></li>
       </ul>

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -62,3 +62,8 @@
 
 {{/* ── JSON-LD structured data ─────────────────────────────────── */}}
 {{ partial "jsonld.html" . }}
+
+{{/* ── Analytics (production builds only) ──────────────────────── */}}
+{{ if hugo.IsProduction }}
+{{ template "_internal/google_analytics.html" . }}
+{{ end }}

--- a/netlify.toml
+++ b/netlify.toml
@@ -12,8 +12,16 @@
 [context.deploy-preview]
   command = "npm ci && npm run css && hugo --gc --minify --buildFuture -b $DEPLOY_PRIME_URL"
 
+# Keep analytics out of previews/branch deploys — head.html gates the GA
+# snippet on hugo.IsProduction, which HUGO_ENV controls.
+[context.deploy-preview.environment]
+  HUGO_ENV = "development"
+
 [context.branch-deploy]
   command = "npm ci && npm run css && hugo --gc --minify -b $DEPLOY_PRIME_URL"
+
+[context.branch-deploy.environment]
+  HUGO_ENV = "development"
 
 [[headers]]
   for = "*.webmanifest"


### PR DESCRIPTION
Four quick wins from the reach analysis, aimed at measurement, distribution, and promoting the OnCall guide.

**Google Analytics finally receives data**

The GA4 property `G-YGZB4EL45B` existed but the tag was never carried over into the current theme, so it recorded nothing. Wired it in via Hugo's `services.googleAnalytics` config + the internal template in `head.html`, gated on `hugo.IsProduction`. Deploy previews and branch deploys now explicitly set `HUGO_ENV=development` in `netlify.toml` so preview traffic doesn't pollute the property.

**Full-text RSS**

`rss.xml` shipped summary-only items. Added `<content:encoded>` with the full rendered post HTML (and the `content:` namespace), keeping `<description>` as the summary. Full-text feeds get read and shared more in aggregators and are friendlier to feed-based syndication.

**OnCall guide promoted on the homepage**

The guide is the site's strongest durable search asset but was reachable only via the nav link. Added a full-width "Field Guide" strip on the homepage (between Recent Talks and Communities), styled after the featured-talk strip: chapter count, one-paragraph pitch, link into `/courses/how-to-make-oncall/`.

**LinkedIn in the footer**

Conference/podcast organizers scout on LinkedIn; the profile link was missing from the site entirely. Added to the footer's "Elsewhere" list.

**Verification**

- `npm run css` + `hugo --gc --minify` build clean; new section, `content:encoded`, LinkedIn link, and gtag snippet all confirmed in `public/` output.
- Playwright suite: 56/56 passing.

**After merge (one manual step):** nothing to register — the GA property already exists. Data should appear in GA4 Realtime within minutes of the production deploy.
