### PR TITLE
Fix home RSS feed emitting section stubs instead of content pages

### DIFF
--- a/layouts/_default/rss.xml
+++ b/layouts/_default/rss.xml
@@ -1,4 +1,11 @@
-{{- $pages := .Data.Pages -}}
+{{- /* .Data.Pages on the home page yields the top-level *sections* (empty
+       stub items), not posts — the home feed should carry every content page
+       on the site, section/term feeds their own regular pages. */ -}}
+{{- $pages := .RegularPages -}}
+{{- if .IsHome -}}
+  {{- $pages = site.RegularPages -}}
+{{- end -}}
+{{- $pages = $pages.ByDate.Reverse -}}
 {{- $limit := site.Config.Services.RSS.Limit -}}
 {{- if ge $limit 1 -}}
   {{- $pages = $pages | first $limit -}}


### PR DESCRIPTION
The site-wide feed at `/index.xml` contained only four stub items — the section index pages (Posts, Talks, Courses, Readers) with empty descriptions, empty `content:encoded`, and year-0001 pubDates. Surfaced when Substack's RSS importer auto-discovered the feed and reported "No posts found"; every feed reader subscribed to "All RSS" from the footer gets the same useless items.

**Cause:** `layouts/_default/rss.xml` iterated `.Data.Pages`, which on the home page yields the top-level *sections*, not content pages. (`.RegularPages` doesn't work either — on the home page it's empty since all content lives inside sections.)

**Fix:** the home feed now uses `site.RegularPages` (every content page on the site), section and term feeds keep their own `.RegularPages`, all sorted newest-first.

**Verification**

- `/index.xml`: 42 items, newest post first, full `content:encoded` — was 4 empty stubs.
- `/post/index.xml`: unchanged, 14 posts.
- Tag feeds (e.g. `/tags/go/index.xml`) render their posts correctly.
- Playwright suite: 56/56 passing.
