### PR TITLE
Add Substack newsletter links to footer and post pages

### DIFF
--- a/config/_default/params.toml
+++ b/config/_default/params.toml
@@ -8,6 +8,11 @@ description = "Personal site of Ladislav Prskavec — Software Engineer & Site R
 # meta tags. Empty disables the tags.
 twitter = "abtris"
 
+# Substack publication (host only) — the email-subscription path for readers
+# who don't use RSS. Rendered in the footer and the end-of-post subscribe
+# line. Empty disables both.
+substack = "abtris.substack.com"
+
 # Contact details. `email` is rendered on the about page and used as the
 # RSS <managingEditor> / <webMaster>. `address` powers the location line
 # on the about page vitals card.

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -14,6 +14,7 @@
         <li><a class="nav-link" href="https://hachyderm.io/@abtris" target="_blank" rel="noopener">hachyderm.io/@abtris ↗</a></li>
         <li><a class="nav-link" href="https://twitter.com/abtris" target="_blank" rel="noopener">twitter.com/abtris ↗</a></li>
         <li><a class="nav-link" href="https://www.linkedin.com/in/ladislavprskavec/" target="_blank" rel="noopener">linkedin.com/in/ladislavprskavec ↗</a></li>
+        {{ with site.Params.substack }}<li><a class="nav-link" href="https://{{ . }}" target="_blank" rel="noopener">{{ . }} (newsletter) ↗</a></li>{{ end }}
         <li><a class="nav-link" href="https://ybyr.net/podcast" target="_blank" rel="noopener">ybyr.net (podcast) ↗</a></li>
         <li><a class="nav-link" href="https://www.gomeetupprague.cz/" target="_blank" rel="noopener">gomeetupprague.cz ↗</a></li>
       </ul>

--- a/layouts/post/single.html
+++ b/layouts/post/single.html
@@ -37,6 +37,15 @@
     </div>
   </div>
 
+  {{/* subscribe — the email path for readers who don't use RSS */}}
+  {{ with site.Params.substack }}
+  <div class="mt-24 pt-8 border-t border-[color:var(--color-rule)] max-w-5xl flex flex-wrap items-baseline gap-x-8 gap-y-3">
+    <span class="mono-label">§ New posts by email</span>
+    <a href="https://{{ . }}" target="_blank" rel="noopener" class="link-arrow">Subscribe on Substack <span class="arr">↗</span></a>
+    <a href="{{ "/post/index.xml" | relURL }}" class="link-quiet">or grab the RSS feed <span class="arr">→</span></a>
+  </div>
+  {{ end }}
+
   {{/* prev/next */}}
   {{ $sectionPages := where site.RegularPages "Section" "post" }}
   {{ $sorted := sort $sectionPages "Date" "desc" }}


### PR DESCRIPTION
Surfaces the new Substack newsletter (abtris.substack.com) as the email-subscription path for readers who don't use RSS.

**Changes**

- New `substack` param in `params.toml` (host only) — single source for both placements; empty disables them.
- Footer "Elsewhere" list gains `abtris.substack.com (newsletter) ↗`.
- Post pages get a quiet subscribe line between the article body and the prev/next nav — "§ New posts by email · Subscribe on Substack ↗ · or grab the RSS feed →" — using the existing `mono-label` / `link-arrow` / `link-quiet` vocabulary and ruled-separator pattern.

**Verification:** clean build; footer link renders site-wide and the subscribe block renders on post pages; Playwright 56/56 passing.
