### PR TITLE
Fix mobile prose overflow in post layout

### DIFF
--- a/layouts/post/single.html
+++ b/layouts/post/single.html
@@ -32,7 +32,7 @@
     <aside class="hidden md:flex justify-end pt-2">
       <span class="vert-label">By Ladislav Prskavec</span>
     </aside>
-    <div class="prose-editorial rise rise-2">
+    <div class="prose-editorial rise rise-2 min-w-0">
       {{ .Content }}
     </div>
   </div>


### PR DESCRIPTION
On iPhone, body paragraphs in a post ran off the right edge instead of wrapping to the screen. The intro/lede wrapped fine, so the difference pointed at the content column.

**Cause:** the article content lives in a CSS grid item, and grid items default to `min-width: auto` — they won't shrink below the intrinsic width of their widest child. A wide code block pushed that minimum past the viewport, so the whole column stretched and every paragraph inherited the over-wide width. Code blocks looked fine only because they scroll internally, which hid the real cause.

**Fix:** add `min-w-0` to the `.prose-editorial` grid item so it can shrink to the viewport and prose wraps again. This is exactly what `reader/single.html` already does — the post layout was just missing it. One line.

Verified at a 500px viewport in Chrome DevTools: no horizontal overflow, all paragraphs constrained to the column, inline code chips still inline, code blocks still scroll.
